### PR TITLE
Fix C1: verify actual sandbox path checks and kernel wiring

### DIFF
--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -4,6 +4,18 @@ on:
     branches: [main]
   pull_request:
 jobs:
+  unc:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Prove sandbox path behavior without a kernel prefix
+        run: node scripts/prove-unc.js
   scan:
     runs-on: ubuntu-latest
     steps:

--- a/BUGS.md
+++ b/BUGS.md
@@ -12,16 +12,6 @@ How to land a change: [CONTRIBUTING.md](CONTRIBUTING.md). What the patches are f
 
 Each row is work that is **not done**. “Done” means the green line in that section, not a comment.
 
-### C1. Behavior tests for the sandbox path check
-
-**Why it is a hole:** `scripts/prove-patches.js` copies a gold prefix, applies patches, and greps for mark strings plus a tiny `isUnc()` helper that is **not** the helper injected into `dsh-sandbox-local`. A patch can apply, the marks stay, and the refuse still never runs.
-
-**Files:** `patches/apply-kernel-patches.js` (the `companyWorkspaceIsNetworkPath` string), `scripts/prove-patches.js`. Better: extract the path helper to something like `patches/lib/network-path.js` and require it from both the patcher and a test.
-
-**Done when:** `node scripts/prove-unc.js` (or equivalent) fails if `\\host\share` and `//host/share` are treated as local, and passes for `C:\Users\dev\proj` and `/Users/dev/proj`, **without** needing `KERNEL_PREFIX`. CI runs it.
-
-**Skill:** Node, no Windows box required.
-
 ### C2. Mapped drive / SUBST is treated as local
 
 **Why it is a hole:** `companyWorkspaceIsNetworkPath` only looks at UNC (`\\` / `//`). A mapped `Z:\team` is a drive letter, so `workspace-write` still tries to plant an NTFS ACL on a network volume. The grant then fails (or confines nothing). The patch comment already admits this; there is no detector.
@@ -96,6 +86,16 @@ This is **not** “the agent is sandboxed.” Review whether (1) can be pointed 
 **Done when:** tests (or a documented rg stderr matrix) show which stderr strings become empty vs `SEARCH_FAILED`. Tighten the matcher if it is too broad; do not revert to “any rg 2 kills the turn” without a replacement.
 
 **Skill:** rg on Windows/macOS, reading `dsh-tool-fs-search`.
+
+---
+
+## Completed contributor work
+
+### C1. Behavior tests for the sandbox path check
+
+`patches/lib/network-path.js` is the single source for the helpers embedded by the patcher and exercised by `scripts/prove-unc.js`. The proof rejects backslash/forward-slash UNC roots, allows local Windows/POSIX roots, applies the actual patch to a minimal fixture, and verifies refusal before grant operations. Negative controls detect a disabled predicate and a disconnected precheck.
+
+**Green:** `node scripts/prove-unc.js` → `UNC_PROVE_OK=1`, without `KERNEL_PREFIX`. CI runs this on Linux and Windows with Node 22. `scripts/prove-patches.js` additionally exercises the method from the patched pinned kernel (`UNC_KERNEL_PROVE_OK=1`). This proves path refusal and call ordering, not real NTFS ACL behavior; mapped drives and the ACL review remain C2/C3.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Kernel bugs that reproduce on **stock** `dsh` with no patch: also post in [upstr
 ## Before a PR
 
 1. `bash scripts/prove-scan.sh` → `SCAN_OK=1`.
+   Run `node scripts/prove-unc.js` → `UNC_PROVE_OK=1` for sandbox path behavior (no kernel install or `KERNEL_PREFIX` needed).
 2. If you touched patches or prove scripts: `node scripts/prove-patches.js` → `PATCH_PROVE_OK=1` (needs a gold prefix: `KERNEL_PREFIX`, or `~/.tdh-coding-prefix` after setup, or `~/dsh-kernel/0-1-1-rc-2`).
 3. Paths and script names ASCII only. UI fonts if you touch CSS: `"Microsoft YaHei", "PingFang SC", "Noto Sans CJK SC", "Noto Sans SC", sans-serif`.
 4. Do not add office IPs, auth keys, roster files, or a live `node_modules` dump.

--- a/patches/apply-kernel-patches.js
+++ b/patches/apply-kernel-patches.js
@@ -15,6 +15,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { sandboxPathHelperSource } = require('./lib/network-path');
 
 const prefix = process.argv[2];
 if (!prefix) {
@@ -62,36 +63,8 @@ const SKILL_MARK = 'company-skill-custom-trusted-v1';
 
 const HELPERS = `
 
-// --- ${MARK} (company patch; see scripts/p-product-base/apply-kernel-patches.js) ---
-function companyWorkspaceIsNetworkPath(p) {
-	return typeof p === "string" && (p.startsWith("\\\\\\\\") || p.startsWith("//"));
-}
-function companyWorkspaceHint(workspaceRoot) {
-	return "workspace-write confinement is granted by an NTFS ACL on the volume that holds the workspace. "
-		+ "\\"" + workspaceRoot + "\\" is not on a local volume, so there is no volume here to grant on and this "
-		+ "sandbox cannot confine anything on it. Put the agent workspace on a local disk and mount the company "
-		+ "share separately: the share is access-controlled on the server (per-person SMB account plus per-dept "
-		+ "NTFS ACL), not by this sandbox.";
-}
-function companyAssertLocalWorkspace(workspaceRoot) {
-	if (!companyWorkspaceIsNetworkPath(workspaceRoot)) return;
-	const err = new Error("sandbox-local: refusing workspace-write on a network workspace. " + companyWorkspaceHint(workspaceRoot));
-	err.code = "COMPANY_WORKSPACE_NOT_LOCAL";
-	throw err;
-}
-function companyGrantError(workspaceRoot, cause) {
-	// Mapped network drives look like a normal drive letter, so the path check
-	// above cannot catch them; they surface here instead. State the hint as a
-	// likely cause rather than a verdict, and keep the original error.
-	const err = new Error(
-		"sandbox-local: windows-acl workspace grant failed for \\"" + workspaceRoot + "\\". "
-		+ "If this workspace is on a mapped network drive or a UNC path, that is the likely cause: "
-		+ companyWorkspaceHint(workspaceRoot),
-		{ cause }
-	);
-	err.code = "COMPANY_WORKSPACE_GRANT_FAILED";
-	return err;
-}
+// --- ${MARK} (company patch; see patches/apply-kernel-patches.js) ---
+${sandboxPathHelperSource()}
 `;
 
 const PATCHES = [

--- a/patches/lib/network-path.js
+++ b/patches/lib/network-path.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// Keep these functions self-contained: the patcher embeds their source into
+// the installed ESM kernel, which must not depend on this checkout at runtime.
+function companyWorkspaceIsNetworkPath(p) {
+  return typeof p === 'string' && (p.startsWith('\\\\') || p.startsWith('//'));
+}
+
+function companyWorkspaceHint(workspaceRoot) {
+  return 'workspace-write confinement is granted by an NTFS ACL on the volume that holds the workspace. '
+    + '"' + workspaceRoot + '" is not on a local volume, so there is no volume here to grant on and this '
+    + 'sandbox cannot confine anything on it. Put the agent workspace on a local disk and mount the company '
+    + 'share separately: the share is access-controlled on the server (per-person SMB account plus per-dept '
+    + 'NTFS ACL), not by this sandbox.';
+}
+
+function companyAssertLocalWorkspace(workspaceRoot) {
+  if (!companyWorkspaceIsNetworkPath(workspaceRoot)) return;
+  const err = new Error('sandbox-local: refusing workspace-write on a network workspace. ' + companyWorkspaceHint(workspaceRoot));
+  err.code = 'COMPANY_WORKSPACE_NOT_LOCAL';
+  throw err;
+}
+
+function companyGrantError(workspaceRoot, cause) {
+  // Mapped drives remain outside this lexical check; see C2 in BUGS.md.
+  const err = new Error(
+    'sandbox-local: windows-acl workspace grant failed for "' + workspaceRoot + '". '
+      + 'If this workspace is on a mapped network drive or a UNC path, that is the likely cause: '
+      + companyWorkspaceHint(workspaceRoot),
+    { cause }
+  );
+  err.code = 'COMPANY_WORKSPACE_GRANT_FAILED';
+  return err;
+}
+
+function sandboxPathHelperSource() {
+  return [companyWorkspaceIsNetworkPath, companyWorkspaceHint,
+    companyAssertLocalWorkspace, companyGrantError].map((fn) => fn.toString()).join('\n');
+}
+
+module.exports = {
+  companyWorkspaceIsNetworkPath,
+  companyAssertLocalWorkspace,
+  companyGrantError,
+  sandboxPathHelperSource,
+};

--- a/scripts/prove-patches.js
+++ b/scripts/prove-patches.js
@@ -74,20 +74,10 @@ for (const [name, ok] of marks) {
   if (!ok) bad = 1;
 }
 
-function isUnc(p) {
-  const s = String(p || '').replace(/\//g, '\\');
-  return s.startsWith('\\\\') || s.startsWith('\\\\?\\UNC\\');
-}
-const cases = [
-  ['UNC_SHARE', isUnc('\\\\fileserver\\teamshare\\desk\\a.md'), true],
-  ['UNC_FWD', isUnc('//fileserver/teamshare/a.md'), true],
-  ['LOCAL_WIN', isUnc('C:\\Users\\dev\\home\\a.md'), false],
-];
-for (const [name, got, want] of cases) {
-  const ok = got === want;
-  console.log((ok ? 'CASE_OK=' : 'CASE_FAIL=') + name);
-  if (!ok) bad = 1;
-}
+execFileSync(process.execPath, [path.join(root, 'scripts', 'prove-unc.js'),
+  '--sandbox-file', path.join(dst, files[0])], {
+  stdio: 'inherit',
+});
 
 if (bad) {
   console.error('PATCH_PROVE_OK=0');

--- a/scripts/prove-unc.js
+++ b/scripts/prove-unc.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Behavior proof for the real sandbox path helpers. No KERNEL_PREFIX required.
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const vm = require('node:vm');
+const { execFileSync } = require('node:child_process');
+const helpers = require('../patches/lib/network-path');
+
+const cases = [
+  ['UNC_BACKSLASH', String.raw`\\host\share`, true],
+  ['UNC_FORWARD', '//host/share', true],
+  ['UNC_NAMESPACED', String.raw`\\?\UNC\host\share`, true],
+  ['LOCAL_WINDOWS', String.raw`C:\Users\dev\proj`, false],
+  ['LOCAL_POSIX', '/Users/dev/proj', false],
+];
+
+function proveHelpers(api) {
+  for (const [name, input, network] of cases) {
+    assert.equal(api.companyWorkspaceIsNetworkPath(input), network, name);
+    if (network) {
+      assert.throws(() => api.companyAssertLocalWorkspace(input), (err) =>
+        err.code === 'COMPANY_WORKSPACE_NOT_LOCAL' && err.message.includes(input), name);
+    } else {
+      assert.doesNotThrow(() => api.companyAssertLocalWorkspace(input), name);
+    }
+  }
+  const cause = new Error('test grant failure');
+  const error = api.companyGrantError('C:\\proj', cause);
+  assert.equal(error.code, 'COMPANY_WORKSPACE_GRANT_FAILED');
+  assert.equal(error.cause, cause);
+}
+
+// A minimal kernel fixture containing the two pinned patch anchors. Running
+// the actual patcher catches a missing/misordered call as well as bad helpers.
+// This is not a Windows ACL integration test; prove-patches checks the real pin.
+const fixture = [
+  'class Sandbox {',
+  '\tmaterializeAclGrant(sessionId, workspaceRoot) {',
+  '\t\tassertTempRootOutsideWorkspace(workspaceRoot, tmpdir());',
+  '\t\t\tlet grant;',
+  '\t\t\ttry {',
+  '\t\t\t\tgrant = grantWorkspace(workspaceRoot);',
+  '\t\t\t} catch (error) {',
+  '\t\t\t\tthrow error;',
+  '\t\t\t}',
+  '\t\t\tthis.workspaceGrants.set(workspaceRoot, grant);',
+  '\t}',
+  '}',
+  'globalThis.Sandbox = Sandbox;',
+  '',
+].join('\n');
+
+function provePatchedSource(source) {
+  const calls = [];
+  const context = vm.createContext({
+    assertTempRootOutsideWorkspace: () => calls.push('temp-check'),
+    tmpdir: () => '/tmp',
+    grantWorkspace: () => { calls.push('grant'); return 'test-grant'; },
+  });
+  vm.runInContext(source, context);
+  proveHelpers(context);
+  const sandbox = new context.Sandbox();
+  sandbox.workspaceGrants = new Map();
+  for (const [name, input, network] of cases) {
+    calls.length = 0;
+    if (network) {
+      assert.throws(() => sandbox.materializeAclGrant('test', input),
+        (err) => err.code === 'COMPANY_WORKSPACE_NOT_LOCAL', name);
+      assert.deepEqual(calls, [], name + ': refused before side effects');
+      assert.equal(sandbox.workspaceGrants.has(input), false, name);
+    } else {
+      sandbox.materializeAclGrant('test', input);
+      assert.deepEqual(calls, ['temp-check', 'grant'], name);
+      assert.equal(sandbox.workspaceGrants.get(input), 'test-grant', name);
+    }
+  }
+}
+
+proveHelpers(helpers);
+// Optional integration check: execute the method extracted from the actual
+// patched kernel. A sentinel stops local paths at the original first operation,
+// so this checks ordering without granting ACLs or needing Windows privileges.
+const fileIdx = process.argv.indexOf('--sandbox-file');
+if (fileIdx >= 0) {
+  const source = fs.readFileSync(process.argv[fileIdx + 1], 'utf8');
+  const method = source.match(/^\tmaterializeAclGrant\(sessionId, workspaceRoot\) \{[\s\S]*?^\t\}/m);
+  assert.ok(method, 'pinned materializeAclGrant method exists');
+  const marker = '// --- company-sandbox-local-unc-v1';
+  const helperStart = source.indexOf(marker);
+  assert.ok(helperStart >= 0, 'sandbox helpers are embedded');
+  const reachedOriginalOperation = new Error('reached original kernel operation');
+  const context = vm.createContext({
+    tmpdir: () => '/tmp',
+    assertTempRootOutsideWorkspace: () => { throw reachedOriginalOperation; },
+  });
+  vm.runInContext(source.slice(helperStart) + '\n'
+    + 'globalThis.sandbox = ({' + method[0] + '\n});', context);
+  proveHelpers(context);
+  for (const [name, input, network] of cases) {
+    assert.throws(() => context.sandbox.materializeAclGrant('test', input),
+      (err) => network ? err.code === 'COMPANY_WORKSPACE_NOT_LOCAL' : err === reachedOriginalOperation,
+      name + ': actual kernel method');
+  }
+  console.log('UNC_KERNEL_PROVE_OK=1');
+}
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tdh-unc-'));
+try {
+  const kernel = path.join(tmp, 'lib', 'node_modules', '@deepseek-ai', 'dsh');
+  const target = path.join(kernel, 'node_modules', '@deepseek-ai', 'dsh-sandbox-local', 'lib', 'index.js');
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(path.join(kernel, 'package.json'), '{}');
+  fs.writeFileSync(target, fixture);
+  execFileSync(process.execPath, [path.join(__dirname, '..', 'patches', 'apply-kernel-patches.js'),
+    tmp, '--only', 'company-sandbox-local-unc-v1'], { stdio: 'pipe' });
+  const patched = fs.readFileSync(target, 'utf8');
+  provePatchedSource(patched);
+
+  // Negative controls: prove this harness detects a disabled check and a
+  // disconnected check, even when all patch marker comments remain present.
+  const disabled = patched.replace('return typeof p ===', 'return false && typeof p ===');
+  assert.notEqual(disabled, patched);
+  assert.throws(() => provePatchedSource(disabled), { code: 'ERR_ASSERTION' });
+  const disconnected = patched.replace('\t\tcompanyAssertLocalWorkspace(workspaceRoot);\n', '');
+  assert.notEqual(disconnected, patched);
+  assert.throws(() => provePatchedSource(disconnected), { code: 'ERR_ASSERTION' });
+  console.log('UNC_PROVE_OK=1');
+} finally {
+  fs.rmSync(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
The sandbox proof previously tested a separate `isUnc()` helper and patch markers, so it could pass even if the real precheck stopped refusing network roots. This change shares the actual helpers between the patcher and behavior tests while embedding them into the installed kernel without a runtime dependency on this checkout.

`prove-unc.js` verifies UNC refusal, local Windows/POSIX acceptance, error codes, and refusal before grant operations on a patched fixture. Negative controls prove it detects a disabled predicate and disconnected precheck. `prove-patches.js` also exercises the method extracted from the patched pinned kernel, stopping local paths at the first original operation to avoid performing ACL changes. A separate Node 22 Linux/Windows CI job runs without a kernel prefix.

Validation on Windows, Node 24.16.0:
- `node scripts/prove-unc.js` with `KERNEL_PREFIX` unset: `UNC_PROVE_OK=1`.
- Existing patch proof against a fresh `@deepseek-ai/dsh@0.1.1-rc.2`: 16 patches applied, `UNC_KERNEL_PROVE_OK=1`, `PATCH_PROVE_OK=1`.
- `bash scripts/prove-scan.sh`: `SCAN_OK=1`.
- `git diff --cached --check`: passed.

Node 22 and Linux checks are configured in CI; they have not yet run locally. This does not claim real NTFS ACL integration coverage and does not change mapped-drive classification (C2) or the privilege review (C3).

Closes #2.
