### PR TITLE
Stop coding setup from pinning company skill roots (C4)

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -39,7 +39,9 @@ This is **not** “the agent is sandboxed.” Review whether (1) can be pointed 
 
 ### C4. Coding setup still pins company skill roots
 
-**Why it is a hole:** `scripts/setup.sh` applies the **full** patcher. That rewrites `standard` / `code` presets with `__DESK_SKILLS__`, `customSkillDirs`, `.company-root`, and `web_fetch: true`. `overlays/solo.yml` does not define those dirs. Company-only preset names (`company-think`) are skipped if missing, but **standard/code still change**.
+**Closed (option a):** `setup.sh` / `setup.ps1` apply only the coding subset (`--only` now takes a comma-separated mark list), so `__DESK_SKILLS__`, custom trustedHost, `web_fetch` and `.company-root` no longer touch the official presets on a coding install. `TDH_FULL_PATCHES=1` keeps the old full-pin behavior for the company desk tree.
+
+**Why it was a hole:** `scripts/setup.sh` applied the **full** patcher. That rewrote `standard` / `code` presets with `__DESK_SKILLS__`, `customSkillDirs`, `.company-root`, and `web_fetch: true`. `overlays/solo.yml` does not define those dirs. Company-only preset names (`company-think`) are skipped if missing, but **standard/code still changed**.
 
 **Files:** `patches/apply-kernel-patches.js` (preset pins at the bottom), `overlays/solo.yml`, `scripts/setup.sh`.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ export DEEPSEEK_API_KEY='your-key'
 dsh --patch "$PWD/overlays/solo.yml"
 ```
 
-Windows: `pwsh -File scripts/setup.ps1`. Setup installs `@deepseek-ai/dsh@0.1.1-rc.2` into `~/.tdh-coding-prefix` and applies patches. Do not point it at a live `node_modules`.
+Windows: `pwsh -File scripts/setup.ps1`. Setup installs `@deepseek-ai/dsh@0.1.1-rc.2` into `~/.tdh-coding-prefix` and applies the coding patch subset (sandbox, junction, glob, session, goal). Do not point it at a live `node_modules`. The company pins (placeholder skill roots, `web_fetch`, `.company-root`) stay off the official presets unless you opt in with `TDH_FULL_PATCHES=1`.
 
 Green: `bash scripts/prove-scan.sh` → `SCAN_OK=1`. After setup: `node scripts/prove-patches.js` → `PATCH_PROVE_OK=1`.
 

--- a/patches/apply-kernel-patches.js
+++ b/patches/apply-kernel-patches.js
@@ -19,11 +19,15 @@ const { sandboxPathHelperSource } = require('./lib/network-path');
 
 const prefix = process.argv[2];
 if (!prefix) {
-  console.error('usage: apply-kernel-patches.js <prefix> [--only <mark>]');
+  console.error('usage: apply-kernel-patches.js <prefix> [--only <mark>[,<mark>...]]');
   process.exit(2);
 }
 const onlyIdx = process.argv.indexOf('--only');
-const onlyMark = onlyIdx >= 0 ? String(process.argv[onlyIdx + 1] || '') : '';
+// --only takes one mark or a comma-separated list; preset pins are skipped
+// in --only mode either way.
+const onlyMarks = new Set(
+  onlyIdx >= 0 ? String(process.argv[onlyIdx + 1] || '').split(',').filter(Boolean) : []
+);
 
 function refuseLivePrefix(raw) {
   const n = path.resolve(raw).replace(/\\/g, '/');
@@ -466,7 +470,7 @@ let applied = 0;
 let skipped = 0;
 
 for (const patch of PATCHES) {
-  if (onlyMark && patch.mark !== onlyMark) continue;
+  if (onlyMarks.size && !onlyMarks.has(patch.mark)) continue;
   const target = path.join(kernelRoot, patch.file);
   if (!fs.existsSync(target)) {
     console.error('PATCH_FAIL=target-missing|' + target);
@@ -513,7 +517,13 @@ for (const patch of PATCHES) {
   applied += 1;
 }
 
-if (onlyMark) {
+if (onlyMarks.size) {
+  for (const mark of onlyMarks) {
+    if (!PATCHES.some((p) => p.mark === mark)) {
+      console.error('PATCH_FAIL=unknown-mark|' + mark);
+      process.exit(1);
+    }
+  }
   console.log('PATCH_APPLIED=' + applied);
   console.log('PATCH_SKIPPED=' + skipped);
   console.log('KERNEL_PATCHES_OK=1');

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -14,7 +14,15 @@ New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
 Write-Output "PIN=$Pin"
 Write-Output "PREFIX=$Prefix"
 npm install -g "@deepseek-ai/dsh@$Pin" --prefix $Prefix
-node (Join-Path $Root "patches\apply-kernel-patches.js") $Prefix
+# Coding setup applies only the local-workspace subset; the company pins
+# (__DESK_SKILLS__ skill roots, web_fetch, .company-root) stay off the
+# official presets unless TDH_FULL_PATCHES=1 (see C4 in BUGS.md).
+$CodingMarks = "company-sandbox-local-unc-v1,company-win-junction-mklink-v3,company-win-junction-mklink-v4,company-glob-missing-root-v1,company-session-smbfs-rename-v1,company-goal-resume-armed-v1"
+if ($env:TDH_FULL_PATCHES -eq "1") {
+  node (Join-Path $Root "patches\apply-kernel-patches.js") $Prefix
+} else {
+  node (Join-Path $Root "patches\apply-kernel-patches.js") $Prefix --only $CodingMarks
+}
 Write-Output "SETUP_OK=1"
 Write-Output "PATH_HINT=$Prefix\bin"
 Write-Output "NEXT=set DEEPSEEK_API_KEY=... then dsh --patch overlays\solo.yml"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,7 +14,17 @@ mkdir -p "$PREFIX"
 echo "PIN=$PIN"
 echo "PREFIX=$PREFIX"
 npm install -g "@deepseek-ai/dsh@${PIN}" --prefix "$PREFIX"
-node "$ROOT/patches/apply-kernel-patches.js" "$PREFIX"
+# Coding setup applies only the local-workspace subset. The full patcher also
+# pins company skill roots (__DESK_SKILLS__), custom trustedHost, web_fetch
+# and .company-root into the official presets, which overlays/solo.yml does
+# not define (C4). TDH_FULL_PATCHES=1 restores the old full-pin behavior for
+# the company desk tree.
+CODING_MARKS="company-sandbox-local-unc-v1,company-win-junction-mklink-v3,company-win-junction-mklink-v4,company-glob-missing-root-v1,company-session-smbfs-rename-v1,company-goal-resume-armed-v1"
+if [ "${TDH_FULL_PATCHES:-}" = "1" ]; then
+  node "$ROOT/patches/apply-kernel-patches.js" "$PREFIX"
+else
+  node "$ROOT/patches/apply-kernel-patches.js" "$PREFIX" --only "$CODING_MARKS"
+fi
 echo "SETUP_OK=1"
 echo "PATH_HINT=$PREFIX/bin"
 echo "NEXT=export PATH=\"$PREFIX/bin:\$PATH\" DEEPSEEK_API_KEY=... && dsh --patch \"$ROOT/overlays/solo.yml\""


### PR DESCRIPTION
Closes #7. Takes C4 option (a).

## What
- `--only` now takes a comma-separated mark list; an unknown mark is a hard `PATCH_FAIL=unknown-mark` instead of a silent no-op. In `--only` mode the preset pins are skipped entirely (they run after the early exit), which is exactly what the coding tree needs.
- `setup.sh` / `setup.ps1` apply only the documented coding subset: `company-sandbox-local-unc-v1`, `company-win-junction-mklink-v3` / `-v4`, `company-glob-missing-root-v1`, `company-session-smbfs-rename-v1`, `company-goal-resume-armed-v1`. `__DESK_SKILLS__`, custom `trustedHost`, `web_fetch` and `.company-root` no longer touch the official `standard`/`code` presets on a coding install.
- `TDH_FULL_PATCHES=1` keeps the previous full-pin behavior for the desk tree.
- README states the subset and the opt-in; BUGS.md closes C4.

## Proof (Windows)
- Minimal fixture + `--only company-goal-resume-armed-v1` → one `PATCHED`, `KERNEL_PATCHES_OK=1`, presets untouched (no `preset-missing` failure despite no preset files in the fixture).
- `--only company-goal-resume-armed-v1,company-bogus-v9` → `PATCH_FAIL=unknown-mark|company-bogus-v9`, exit 1.
- `prove-scan.sh` → `SCAN_OK=1`; `prove-unc.js` → `UNC_PROVE_OK=1`.
- CI's patches job exercises the full (no-`--only`) path against the 0.1.1 pin, unchanged.