### PR TITLE
Land PR #12 session-events alias onto main after #9

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -111,6 +111,7 @@ These already have marks in `patches/apply-kernel-patches.js`. File a bug if the
 | P4 | New session `ENOTSUP` / `link` on smbfs | `company-session-smbfs-rename-v1` |
 | P5 | App Translocation `EROFS` writing into a `.app` | `runtime/mac-no-translocate.sh` (CLI tree does not ship a DMG) |
 | P6 | Goal resume of an already-armed goal throws `GOAL_INVALID_TRANSITION` | `company-goal-resume-armed-v1` |
+| P7 | On 0.1.2, presets reading `session.events.length` (tool-bootstrap et al.) TypeError on first assemble; UI says UNKNOWN | `company-session-events-alias-v1` |
 
 ---
 

--- a/patches/apply-kernel-patches.js
+++ b/patches/apply-kernel-patches.js
@@ -457,16 +457,64 @@ const PATCHES = [
       },
     ],
   },
+  {
+    // 0.1.2 removed Session.events; community presets (tool-bootstrap et al.)
+    // still read session.events.length and die with a TypeError on the first
+    // assemble, which the UI reports as UNKNOWN. Alias it to snapshotEvents().
+    // Skipped on 0.1.1, where Session still has its own events.
+    file: path.join('node_modules', '@deepseek-ai', 'dsh-session', 'lib', 'index.js'),
+    mark: 'company-session-events-alias-v1',
+    minKernel: '0.1.2',
+    append:
+      '\n// --- company-session-events-alias-v1 (company patch; see scripts/p-product-base/apply-kernel-patches.js) ---\n',
+    edits: [
+      {
+        name: 'session-events-getter',
+        from:
+          '\teventAt(seq) {\n' +
+          '\t\treturn this.log[seq];\n' +
+          '\t}\n',
+        to:
+          '\teventAt(seq) {\n' +
+          '\t\treturn this.log[seq];\n' +
+          '\t}\n' +
+          '\tget events() {\n' +
+          '\t\treturn this.snapshotEvents();\n' +
+          '\t}\n',
+      },
+    ],
+  },
 ];
 
 const kernelRoot = resolveKernelRoot();
 console.log('PATCH_KERNEL_ROOT=' + kernelRoot);
+const KERNEL_VERSION = JSON.parse(fs.readFileSync(path.join(kernelRoot, 'package.json'), 'utf8')).version;
+console.log('PATCH_KERNEL_VERSION=' + KERNEL_VERSION);
+
+// Some patches only exist because a newer kernel removed or rewrote a
+// surface. `minKernel` skips them on older pins with a loud line instead of
+// an anchor failure. Prerelease tags are stripped: 0.1.2-rc.1 counts as the
+// 0.1.2 line.
+function kernelBelowMin(version, min) {
+  const parts = (v) => String(v).split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const a = parts(version);
+  const b = parts(min);
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] < b[i];
+  }
+  return false;
+}
 
 let applied = 0;
 let skipped = 0;
 
 for (const patch of PATCHES) {
   if (onlyMark && patch.mark !== onlyMark) continue;
+  if (patch.minKernel && kernelBelowMin(KERNEL_VERSION, patch.minKernel)) {
+    console.log('PATCH_SKIP_KERNEL=' + patch.file + '|' + patch.mark + '|kernel=' + KERNEL_VERSION + '|needs>=' + patch.minKernel);
+    skipped += 1;
+    continue;
+  }
   const target = path.join(kernelRoot, patch.file);
   if (!fs.existsSync(target)) {
     console.error('PATCH_FAIL=target-missing|' + target);

--- a/scripts/prove-patches.js
+++ b/scripts/prove-patches.js
@@ -39,6 +39,7 @@ const files = [
   path.join('node_modules', '@deepseek-ai', 'dsh-app-boot', 'lib', 'index.js'),
   path.join('node_modules', '@deepseek-ai', 'dsh-tool-fs-search', 'lib', 'index.js'),
   path.join('node_modules', '@deepseek-ai', 'dsh-session-persistence-jsonl', 'lib', 'index.js'),
+  path.join('node_modules', '@deepseek-ai', 'dsh-session', 'lib', 'index.js'),
   path.join('config', 'agent-presets', 'standard', 'agent.cordis.yml'),
   path.join('config', 'agent-presets', 'code', 'agent.cordis.yml'),
 ];
@@ -63,10 +64,18 @@ execFileSync(process.execPath, [path.join(root, 'patches', 'apply-kernel-patches
 });
 
 const boot = fs.readFileSync(path.join(dst, files[4]), 'utf8');
+// company-session-events-alias-v1 is minKernel-gated: it must be present on
+// the 0.1.2 line (where official removed Session.events) and absent on 0.1.1
+// (where Session still has its own). Prerelease tags do not count.
+const goldVersion = JSON.parse(fs.readFileSync(path.join(src, 'package.json'), 'utf8')).version;
+const goldNums = String(goldVersion).split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+const goldIs012Line = goldNums[0] > 0 || goldNums[1] > 1 || (goldNums[1] === 1 && goldNums[2] >= 2);
+const sessionText = fs.readFileSync(path.join(dst, files[7]), 'utf8');
 const marks = [
   ['JUNCTION_V3', boot.includes('company-win-junction-mklink-v3') || boot.includes('companyWinJunction')],
   ['JUNCTION_V4', boot.includes('SystemRoot') || boot.includes('company-win-junction-mklink-v4')],
   ['SANDBOX', fs.readFileSync(path.join(dst, files[0]), 'utf8').includes('company-sandbox-local-unc-v1')],
+  ['SESSION_EVENTS_ALIAS', sessionText.includes('company-session-events-alias-v1') === goldIs012Line],
 ];
 let bad = 0;
 for (const [name, ok] of marks) {


### PR DESCRIPTION
Resolves and lands https://github.com/398894496-arch/TDHarness-coding/pull/12 on current main (#10 + #9/C2).

Conflict resolution in prove-patches.js:
- keep drive-v2 SANDBOX prove
- copy `dsh-session` from gold
- do not require `config/` presets (0.1.2 moved them)
- SESSION_EVENTS_ALIAS must be absent on 0.1.1 and present on 0.1.2

Local prove:
- 0.1.1-rc.2: skip `company-session-events-alias-v1`, `PATCH_PROVE_OK` `BUMP_PROVE_OK=1`
- 0.1.2-rc.1: alias lands, `PATCH_PROVE_OK` `BUMP_PROVE_OK=1`

Revert: `git revert -m 1 <merge sha>`.


Made with [Cursor](https://cursor.com)