### PR TITLE
Pin setup and CI to 0.1.2-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ export DEEPSEEK_API_KEY='your-key'
 dsh --patch "$PWD/overlays/solo.yml"
 ```
 
-Windows: `pwsh -File scripts/setup.ps1`. Setup installs `@deepseek-ai/dsh@0.1.1-rc.2` into `~/.tdh-coding-prefix` and applies patches. Do not point it at a live `node_modules`.
+Windows: `pwsh -File scripts/setup.ps1`. Setup installs `@deepseek-ai/dsh@0.1.2-rc.1` into `~/.tdh-coding-prefix` and applies patches. Do not point it at a live `node_modules`.
 
 Green: `bash scripts/prove-scan.sh` → `SCAN_OK=1`. After setup: `node scripts/prove-patches.js` → `PATCH_PROVE_OK=1`.
 

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -28,7 +28,7 @@ Open a **new** General thread only if stock dsh still reproduces **and** the exi
 ## Template
 
 ```
-**dsh:** 0.1.1-rc.2 (stock, no overlay)
+**dsh:** 0.1.2-rc.1 (stock, no overlay)
 **OS:** Windows 11 / macOS …
 **Repro:** (shortest steps, local paths only)
 **Expected:**

--- a/kernel.yml
+++ b/kernel.yml
@@ -1,4 +1,4 @@
 # Pin only. Overlay lives in overlays/. Never npm-update a live prefix.
-id: 0.1.1-rc.2
+id: 0.1.2-rc.1
 package: "@deepseek-ai/dsh"
-candidate: 0.1.1-rc.2
+candidate: 0.1.2-rc.1


### PR DESCRIPTION
Fourth step of the upgrade line after #10 / #9 / #12.

Changes only the advertised pin (`kernel.yml`, README, UPSTREAM). Setup and CI already read `kernel.yml`.

Local prove on throwaway prefixes:
- `prove-bump.js 0.1.2-rc.1` → `BUMP_PROVE_OK=1`
- `prove-patches.js` against 0.1.2-rc.1 gold → `PATCH_PROVE_OK=1`
- `prove-bump.js 0.1.1-rc.2` still green (gate skip for P7)

Revert: `git revert <this sha>` or revert the merge commit.


Made with [Cursor](https://cursor.com)