### PR TITLE
Merge PR #13 assistant markdown slot (P8)

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -111,6 +111,7 @@ These already have marks in `patches/apply-kernel-patches.js`. File a bug if the
 | P4 | New session `ENOTSUP` / `link` on smbfs | `company-session-smbfs-rename-v1` |
 | P5 | App Translocation `EROFS` writing into a `.app` | `runtime/mac-no-translocate.sh` (CLI tree does not ship a DMG) |
 | P6 | Goal resume of an already-armed goal throws `GOAL_INVALID_TRANSITION` | `company-goal-resume-armed-v1` |
+| P8 | On 0.1.2, plugins cannot override assistant markdown rendering (images, richer syntax) | `company-assistant-markdown-slot-v1` |
 
 ---
 

--- a/patches/apply-kernel-patches.js
+++ b/patches/apply-kernel-patches.js
@@ -61,6 +61,46 @@ function resolveKernelRoot() {
 const MARK = 'company-sandbox-local-unc-v1';
 const SKILL_MARK = 'company-skill-custom-trusted-v1';
 
+const MARKDOWN_SLOT_PATCH = {
+    // 0.1.2 renders assistant markdown through a fixed MarkdownText
+    // primitive; a plugin (company desk image rendering, syntax extensions)
+    // cannot override it. Open a `conversation.assistant.markdown` render
+    // slot with the official primitive as the fallback. Skipped on 0.1.1,
+    // which ships no dsh-client-ui-chat package at all.
+    file: path.join('node_modules', '@deepseek-ai', 'dsh-client-ui-chat', 'lib', 'client.js'),
+    mark: 'company-assistant-markdown-slot-v1',
+    minKernel: '0.1.2',
+    append:
+      '\n// --- company-assistant-markdown-slot-v1 (company patch; see scripts/p-product-base/apply-kernel-patches.js) ---\n',
+    edits: [
+      {
+        name: 'markdown-render-prop',
+        from: 'function AssistantMarkdown({ blocks, streaming, interrupted, renderMessageImages,',
+        to: 'function AssistantMarkdown({ blocks, streaming, interrupted, renderMarkdown, renderMessageImages,',
+      },
+      {
+        name: 'assistant-markdown-slot-render',
+        from: '\t\t\t\t\t\trendered.push((0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.MarkdownText, {\n\t\t\t\t\t\t\ttext: block.text,\n\t\t\t\t\t\t\tstreaming,\n\t\t\t\t\t\t\tlabels,\n\t\t\t\t\t\t\tfileMentions: mentions\n\t\t\t\t\t\t}, i));',
+        to: '\t\t\t\t\t\trendered.push((0, react_jsx_runtime.jsx)(react.Fragment, { children: renderMarkdown({ text: block.text, streaming, labels, fileMentions: mentions }) }, i));',
+      },
+      {
+        name: 'assistant-node-render-slot',
+        from: 'function AssistantNodeView({ node, useTurnData,',
+        to: 'function AssistantNodeView({ node, renderSlot, useTurnData,',
+      },
+      {
+        name: 'assistant-node-markdown-fallback',
+        from: 'return (0, react_jsx_runtime.jsx)(AssistantMarkdown, {\n\t\t\t\tblocks: data.blocks,',
+        to: 'return (0, react_jsx_runtime.jsx)(AssistantMarkdown, {\n\t\t\t\trenderMarkdown: (props) => renderSlot("conversation.assistant.markdown", props, { fallback: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.MarkdownText, props) }),\n\t\t\t\tblocks: data.blocks,',
+      },
+      {
+        name: 'assistant-markdown-child-slot',
+        from: 'key: "assistant-step",\n\t\t\t\tlocale: NS\n\t\t\t}, AssistantNodeView)',
+        to: 'key: "assistant-step",\n\t\t\t\tlocale: NS,\n\t\t\t\tchildren: { "conversation.assistant.markdown": { kind: "single", scope: "session" } }\n\t\t\t}, AssistantNodeView)',
+      },
+    ],
+};
+
 const HELPERS = `
 
 // --- ${MARK} (company patch; see patches/apply-kernel-patches.js) ---
@@ -68,6 +108,7 @@ ${sandboxPathHelperSource()}
 `;
 
 const PATCHES = [
+  MARKDOWN_SLOT_PATCH,
   {
     file: path.join('node_modules', '@deepseek-ai', 'dsh-sandbox-local', 'lib', 'index.js'),
     mark: MARK,
@@ -461,12 +502,33 @@ const PATCHES = [
 
 const kernelRoot = resolveKernelRoot();
 console.log('PATCH_KERNEL_ROOT=' + kernelRoot);
+const KERNEL_VERSION = JSON.parse(fs.readFileSync(path.join(kernelRoot, 'package.json'), 'utf8')).version;
+console.log('PATCH_KERNEL_VERSION=' + KERNEL_VERSION);
+
+// Some patches only exist because a newer kernel removed or rewrote a
+// surface. `minKernel` skips them on older pins with a loud line instead of
+// an anchor failure. Prerelease tags are stripped: 0.1.2-rc.1 counts as the
+// 0.1.2 line.
+function kernelBelowMin(version, min) {
+  const parts = (v) => String(v).split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const a = parts(version);
+  const b = parts(min);
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] < b[i];
+  }
+  return false;
+}
 
 let applied = 0;
 let skipped = 0;
 
 for (const patch of PATCHES) {
   if (onlyMark && patch.mark !== onlyMark) continue;
+  if (patch.minKernel && kernelBelowMin(KERNEL_VERSION, patch.minKernel)) {
+    console.log('PATCH_SKIP_KERNEL=' + patch.file + '|' + patch.mark + '|kernel=' + KERNEL_VERSION + '|needs>=' + patch.minKernel);
+    skipped += 1;
+    continue;
+  }
   const target = path.join(kernelRoot, patch.file);
   if (!fs.existsSync(target)) {
     console.error('PATCH_FAIL=target-missing|' + target);

--- a/scripts/prove-patches.js
+++ b/scripts/prove-patches.js
@@ -42,6 +42,11 @@ const files = [
   path.join('config', 'agent-presets', 'standard', 'agent.cordis.yml'),
   path.join('config', 'agent-presets', 'code', 'agent.cordis.yml'),
 ];
+// 0.1.2-only targets: absent from a 0.1.1 gold, which is exactly what the
+// patcher's minKernel gate is for. Copied when the gold has them.
+const OPTIONAL_FILES = [
+  path.join('node_modules', '@deepseek-ai', 'dsh-client-ui-chat', 'lib', 'client.js'),
+];
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tdh-coding-patch-'));
 const dst = path.join(tmp, 'lib', 'node_modules', '@deepseek-ai', 'dsh');
@@ -57,16 +62,34 @@ for (const rel of files) {
   fs.mkdirSync(path.dirname(to), { recursive: true });
   fs.copyFileSync(from, to);
 }
+for (const rel of OPTIONAL_FILES) {
+  const from = path.join(src, rel);
+  if (!fs.existsSync(from)) {
+    console.log('PROVE_FILE_SKIP=' + rel + '|absent-from-gold');
+    continue;
+  }
+  const to = path.join(dst, rel);
+  fs.mkdirSync(path.dirname(to), { recursive: true });
+  fs.copyFileSync(from, to);
+}
 
 execFileSync(process.execPath, [path.join(root, 'patches', 'apply-kernel-patches.js'), tmp], {
   stdio: 'inherit',
 });
 
 const boot = fs.readFileSync(path.join(dst, files[4]), 'utf8');
+const goldVersion = JSON.parse(fs.readFileSync(path.join(src, 'package.json'), 'utf8')).version;
+const goldNums = String(goldVersion).split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+const goldIs012Line = goldNums[0] > 0 || goldNums[1] > 1 || (goldNums[1] === 1 && goldNums[2] >= 2);
+const chatRel = OPTIONAL_FILES[0];
+const chatText = fs.existsSync(path.join(dst, chatRel)) ? fs.readFileSync(path.join(dst, chatRel), 'utf8') : '';
 const marks = [
   ['JUNCTION_V3', boot.includes('company-win-junction-mklink-v3') || boot.includes('companyWinJunction')],
   ['JUNCTION_V4', boot.includes('SystemRoot') || boot.includes('company-win-junction-mklink-v4')],
   ['SANDBOX', fs.readFileSync(path.join(dst, files[0]), 'utf8').includes('company-sandbox-local-unc-v1')],
+  // The markdown slot patch is minKernel-gated to the 0.1.2 line, where
+  // dsh-client-ui-chat first ships; it must land there and stay off 0.1.1.
+  ['MARKDOWN_SLOT', chatText.includes('company-assistant-markdown-slot-v1') === (goldIs012Line && chatText !== '')],
 ];
 let bad = 0;
 for (const [name, ok] of marks) {


### PR DESCRIPTION
## Summary
- Lands P8 onto current main after #10 / #9 / #12 / pin / #11.
- Opens a session-scoped `conversation.assistant.markdown` render slot on 0.1.2; official `MarkdownText` stays the fallback.
- Same `minKernel` gate as P7: `PATCH_SKIP_KERNEL` on 0.1.1 (no `dsh-client-ui-chat`).
- Keeps current `--only` comma-list, `drive-v2` prove, and session-events assert. Coding setup subset does **not** include this mark (`TDH_FULL_PATCHES=1` still does).

Closes #8.
Supersedes #13.

## Test
- `SCAN_OK=1` `UNC_PROVE_OK=1`
- prove-patches 0.1.1: `PROVE_FILE_SKIP` + `PATCH_SKIP_KERNEL` for markdown, `MARK_OK=MARKDOWN_SLOT` `SESSION_EVENTS_ALIAS` `PATCH_PROVE_OK=1`
- prove-patches 0.1.2: five markdown edits land, `MARK_OK=MARKDOWN_SLOT` `PATCH_PROVE_OK=1`
- `BUMP_PROVE_OK=1` on `0.1.2-rc.1` (includes the chat-client mark)
- `--only company-assistant-markdown-slot-v1` on a 0.1.2 fixture: slot name + official fallback present

Revert this merge: `git revert -m 1 <this merge commit after it lands on main>`

Made with [Cursor](https://cursor.com)