### PR TITLE
Prove C7 Windows junction creation through the runtime shim

### DIFF
--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -18,6 +18,9 @@ jobs:
         run: node scripts/prove-unc.js
       - name: Prove drive classification and Windows SUBST refusal
         run: node scripts/prove-windows-drives.js
+      - name: Prove real Windows junction creation through the runtime shim
+        if: runner.os == 'Windows'
+        run: node scripts/prove-junction.js
   scan:
     runs-on: ubuntu-latest
     steps:

--- a/BUGS.md
+++ b/BUGS.md
@@ -67,6 +67,8 @@ This is **not** “the agent is sandboxed.” Review whether (1) can be pointed 
 
 ### C7. Windows junction: cmd cwd is SystemRoot (integration)
 
+**Closed:** `node scripts/prove-junction.js` loads the runtime shim in an isolated child, executes real `mklink /J` through both sync and async APIs, and verifies the invocation uses `%SystemRoot%` as cwd. It checks paths containing spaces, resolved targets, reads/writes through each junction, and target preservation after unlinking. Windows CI runs this without requesting elevation or changing Developer Mode. Success prints `JUNCTION_PROVE_OK=1`; other platforms report a skip. No real UNC share is exercised (`JUNCTION_UNC_SKIP`); this proves the local-cwd case and the selected cmd cwd, not operation from a real share or the kernel's separate anchored implementation.
+
 **Why it is a hole:** v4 sets `cwd` to `%SystemRoot%` so `mklink /J` works when the process cwd is UNC. prove-patches only greps `SystemRoot` in `dsh-app-boot`. Nobody runs `mklink` in CI.
 
 **Files:** `runtime/win-junction-shim.cjs`, junction marks in the patcher. A small `scripts/prove-junction.ps1` that creates a temp dir, `--require` the shim (or calls the same spawn), and checks the junction.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ Kernel bugs that reproduce on **stock** `dsh` with no patch: also post in [upstr
 CI on this repo runs the scan and (when npm can install the pin) the patch prove. A red X on your PR is the same bar.
 
 ## Patch rules
+On Windows, run `node scripts/prove-junction.js` to exercise the runtime junction shim with real `mklink /J`, without a kernel prefix. It checks sync/async creation, file access, SystemRoot cwd, and cleanup. It does not test a real UNC share; non-Windows hosts skip explicitly.
+
 
 Kernel edits go through `patches/apply-kernel-patches.js` as **anchored** replacements. If an anchor is not unique, fail. Do not vendor a whole upstream file.
 

--- a/scripts/prove-junction.js
+++ b/scripts/prove-junction.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+if (process.platform !== 'win32') {
+  console.log('JUNCTION_PROVE_SKIP=requires-Windows');
+  process.exit(0);
+}
+
+async function worker(root) {
+  const calls = [];
+  const originalSpawn = cp.spawnSync;
+  // Observe the real process invocation, without replacing mklink with a mock.
+  cp.spawnSync = function (file, args, options) {
+    calls.push({ file, args, cwd: options.cwd });
+    return originalSpawn.apply(this, arguments);
+  };
+  require('../runtime/win-junction-shim.cjs');
+  const target = path.join(root, 'target with spaces');
+  fs.mkdirSync(target);
+  fs.writeFileSync(path.join(target, 'proof.txt'), 'junction-proof');
+  for (const mode of ['sync', 'async']) {
+    const link = path.join(root, mode + ' link');
+    if (mode === 'sync') fs.symlinkSync(target, link, 'junction');
+    else await fs.promises.symlink(target, link, 'junction');
+    assert.equal(fs.lstatSync(link).isSymbolicLink(), true);
+    assert.equal(fs.realpathSync.native(link), fs.realpathSync.native(target));
+    assert.equal(fs.readFileSync(path.join(link, 'proof.txt'), 'utf8'), 'junction-proof');
+    fs.writeFileSync(path.join(link, mode + '.txt'), mode);
+    assert.equal(fs.readFileSync(path.join(target, mode + '.txt'), 'utf8'), mode);
+    // Unlink only the junction, then prove that its target survived.
+    fs.unlinkSync(link);
+    assert.equal(fs.existsSync(link), false);
+    assert.equal(fs.readFileSync(path.join(target, 'proof.txt'), 'utf8'), 'junction-proof');
+  }
+  assert.equal(calls.length, 2, 'both APIs must invoke the shim');
+  for (const call of calls) {
+    assert.equal(call.file.toLowerCase(), 'cmd.exe');
+    assert.deepEqual(call.args.slice(0, 3), ['/c', 'mklink', '/J']);
+    assert.equal(path.resolve(call.cwd).toLowerCase(),
+      path.resolve(process.env.SystemRoot || 'C:\\Windows').toLowerCase());
+  }
+  console.log('JUNCTION_WORKER_OK=1');
+}
+
+if (process.argv[2] === '--worker') {
+  worker(process.argv[3]).catch((err) => { console.error(err); process.exitCode = 1; });
+} else {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tdh-junction-'));
+  try {
+    const result = cp.spawnSync(process.execPath, [__filename, '--worker', root], {
+      cwd: root, encoding: 'utf8', windowsHide: true, timeout: 30000,
+    });
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /JUNCTION_WORKER_OK=1/);
+  } finally {
+    assert.equal(path.dirname(root), path.resolve(os.tmpdir()));
+    assert.ok(path.basename(root).startsWith('tdh-junction-'));
+    // Remove any junction left by a failing assertion before recursive cleanup.
+    for (const name of ['sync link', 'async link']) {
+      const link = path.join(root, name);
+      if (fs.existsSync(link) && fs.lstatSync(link).isSymbolicLink()) fs.unlinkSync(link);
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  console.log('JUNCTION_UNC_SKIP=no-real-share-tested');
+  console.log('JUNCTION_PROVE_OK=1');
+}


### PR DESCRIPTION
C7 previously checked junction patch markers without executing mklink. This adds a Windows integration proof of the existing runtime shim: both sync and async symlink APIs create real junctions with space-containing paths, resolve to the expected target, allow file reads/writes, and preserve the target after unlinking. The proof observes the real cmd invocation and asserts SystemRoot cwd; no mock replaces mklink.

Windows CI now runs the proof on Node 22. Local Windows / Node 24.16.0 validation: JUNCTION_PROVE_OK=1, UNC_PROVE_OK=1, PATCH_PROVE_OK=1 (existing 0.1.1-rc.2 test prefix), SCAN_OK=1 and clean diff check. The existing patches CI verifies the current 0.1.2-rc.1 pin.

The test requests no elevation and does not modify Developer Mode. It does not prove Developer Mode is disabled on the host. Real UNC cwd is explicitly reported as untested; the separate kernel anchored implementation is not exercised by this shim test. Temporary junctions and directories are cleaned up.

Closes #19.
