### PR TITLE
Fix C6: reject tracked secrets while preserving office scans

### DIFF
--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -22,8 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Office-fingerprint scan
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Office-fingerprint and tracked-secret scan
         run: bash scripts/prove-scan.sh
+      - name: Prove the scan rejects synthetic secrets and every office needle
+        run: node scripts/prove-secret-scan.js
   patches:
     runs-on: ubuntu-latest
     steps:

--- a/BUGS.md
+++ b/BUGS.md
@@ -57,6 +57,10 @@ This is **not** “the agent is sandboxed.” Review whether (1) can be pointed 
 
 ### C6. Secret scan is office needles only
 
+**Closed:** `scripts/prove-scan.sh` preserves all seven office needles and then runs `node scripts/scan-secrets.js`. The added scan reads tracked working-tree files (including force-added ignored files) and detects common GitHub tokens, `sk-` vendor keys, AWS access-key IDs, private-key headers, and sensitive `.env` filenames. Diagnostics contain only file/rule/line, never matched contents. Git/read errors, symlinks, submodules and unmerged entries fail closed. `node scripts/prove-secret-scan.js` creates a throwaway Git repository, checks synthetic credentials and every original office needle through the real shell entrypoint, and prints `SECRET_SCAN_PROVE_OK=1`; CI runs both the scan and its proof.
+
+**Limits:** this is a bounded format scan of tracked working-tree contents, not full Git history, secret validity, entropy analysis, encoded secrets, every provider format, or untracked files. `.env.example`, `.env.sample`, and `.env.template` are allowed names but their contents are still scanned. Run from a Git checkout with Node 22+, Git and Bash; archive-only scans no longer report success without Git. A future general-purpose scanner can extend this coverage without removing the office needles.
+
 **Why it is a hole:** `scripts/prove-scan.sh` greps a fixed office-fingerprint list (see that file). A new key format or a personal `.env` committed by a contributor can pass `SCAN_OK=1`.
 
 **Files:** `scripts/prove-scan.sh`, `.github/workflows/prove.yml`. Adding gitleaks/trufflehog **in addition to** the office needles is fine. Do not remove the office needles.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Kernel bugs that reproduce on **stock** `dsh` with no patch: also post in [upstr
 ## Before a PR
 
 1. `bash scripts/prove-scan.sh` → `SCAN_OK=1`.
+   This requires a Git checkout, Node 22+, Git and Bash. It preserves office fingerprints and checks tracked files for common secret formats and sensitive `.env` names. Run `node scripts/prove-secret-scan.js` → `SECRET_SCAN_PROVE_OK=1` to prove rejection with synthetic secrets in a temporary repository. Reports redact values. Only `.env.example`, `.env.sample` and `.env.template` are allowed environment-template names, and their contents are still checked. This is not a scan of full history or every provider's key format.
    Run `node scripts/prove-unc.js` → `UNC_PROVE_OK=1` for sandbox path behavior (no kernel install or `KERNEL_PREFIX` needed).
    Run `node scripts/prove-windows-drives.js` for drive classification; Windows also proves real SUBST refusal (`WINDOWS_DRIVE_PROVE_OK=1`). Optional `TDH_TEST_MAPPED_ROOT` tests an existing network drive without changing its mapping.
 2. If you touched patches or prove scripts: `node scripts/prove-patches.js` → `PATCH_PROVE_OK=1` (needs a gold prefix: `KERNEL_PREFIX`, or `~/.tdh-coding-prefix` after setup, or `~/dsh-kernel/0-1-1-rc-2`).

--- a/scripts/prove-scan.sh
+++ b/scripts/prove-scan.sh
@@ -43,4 +43,5 @@ if [ "$bad" -ne 0 ]; then
   echo "SCAN_OK=0" >&2
   exit 1
 fi
+node scripts/scan-secrets.js
 echo "SCAN_OK=1"

--- a/scripts/prove-secret-scan.js
+++ b/scripts/prove-secret-scan.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync, spawnSync } = require('node:child_process');
+
+const git = process.env.TDH_TEST_GIT || 'git';
+const bash = process.env.TDH_TEST_BASH || 'bash';
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tdh-secret-proof-'));
+const source = path.resolve(__dirname, '..');
+try {
+  fs.mkdirSync(path.join(root, 'scripts'));
+  for (const file of ['prove-scan.sh', 'scan-secrets.js']) {
+    fs.copyFileSync(path.join(source, 'scripts', file), path.join(root, 'scripts', file));
+  }
+  const gitRun = (args) => execFileSync(git, args, { cwd: root, stdio: 'pipe' });
+  gitRun(['init', '--quiet']);
+  fs.writeFileSync(path.join(root, '.gitignore'), '.env\n.env.*\n');
+  gitRun(['add', 'scripts', '.gitignore']);
+  const scan = () => {
+    const result = spawnSync(bash, ['scripts/prove-scan.sh'], {
+      cwd: root, encoding: 'utf8', windowsHide: true, timeout: 30000,
+    });
+    assert.ifError(result.error);
+    return { status: result.status, output: result.stdout + result.stderr };
+  };
+  const clean = scan();
+  assert.equal(clean.status, 0, clean.output);
+  assert.match(clean.output, /SECRET_SCAN_OK=1/);
+  assert.match(clean.output, /\bSCAN_OK=1/);
+
+  // Values are generated only in the temporary repository. No real credentials.
+  const cases = [
+    ['github', 'note.txt', 'gh' + 'p_' + 'A1b2'.repeat(9)],
+    ['github-fine', 'nested/file with spaces.txt', 'github_' + 'pat_' + 'aB3_'.repeat(22)],
+    ['vendor', 'config.txt', 's' + 'k-' + 'a1b2'.repeat(8)],
+    ['vendor-project', 'config.txt', 's' + 'k-proj-' + 'aB3_'.repeat(24)],
+    ['cloud', 'config.txt', 'AK' + 'IA' + 'A1B2'.repeat(4)],
+    ['temporary-cloud', 'config.txt', 'AS' + 'IA' + 'A1B2'.repeat(4)],
+    ['private-key', 'key.txt', '-----BEGIN ' + 'PRIVATE KEY-----'],
+    ['env', '.env', 'PASSWORD=ordinary-text'],
+    ['env-production', 'nested/.env.production', 'SETTING=ordinary-text'],
+    ['secret-in-template', '.env.example', 's' + 'k-' + 'a1b2'.repeat(8)],
+  ];
+  for (const [name, file, value] of cases) {
+    const full = path.join(root, file);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, value + '\n');
+    gitRun(['add', '--force', '--', file]);
+    const result = scan();
+    assert.equal(result.status, 1, name + ': ' + result.output);
+    assert.match(result.output, /SECRET_HIT=/, name);
+    assert.doesNotMatch(result.output, /\bSCAN_OK=1/, name);
+    assert.ok(!result.output.includes(value), name + ': secret must be redacted');
+    gitRun(['rm', '--force', '--', file]);
+  }
+  const shell = fs.readFileSync(path.join(source, 'scripts/prove-scan.sh'), 'utf8');
+  const block = shell.match(/needles=\(([\s\S]*?)\)/);
+  assert.ok(block, 'office needle list remains present');
+  const needles = [...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1].replace(/\\(.)/g, '$1'));
+  assert.equal(needles.length, 7, 'all original office needles retained');
+  for (const value of needles) {
+    fs.writeFileSync(path.join(root, 'office.txt'), value + '\n');
+    gitRun(['add', 'office.txt']);
+    const result = scan();
+    assert.equal(result.status, 1, 'office needle must fail');
+    assert.match(result.output, /SCAN_HIT=/);
+    assert.doesNotMatch(result.output, /\bSCAN_OK=1/);
+    gitRun(['rm', '--force', 'office.txt']);
+  }
+  fs.writeFileSync(path.join(root, '.env.example'), 'DEEPSEEK_API_KEY=your-key\n');
+  gitRun(['add', '--force', '.env.example']);
+  assert.equal(scan().status, 0, 'placeholder templates remain allowed');
+  // A missing tracked file and an invalid Git executable are operational errors.
+  fs.unlinkSync(path.join(root, '.env.example'));
+  assert.notEqual(scan().status, 0, 'unreadable tracked file must not pass');
+  const invalidGit = spawnSync(process.execPath, [path.join(root, 'scripts/scan-secrets.js')], {
+    cwd: root, encoding: 'utf8', env: { ...process.env, TDH_TEST_GIT: path.join(root, 'not-a-git') },
+  });
+  assert.equal(invalidGit.status, 2);
+  console.log('SECRET_SCAN_PROVE_OK=1');
+} finally {
+  assert.equal(path.dirname(root), path.resolve(os.tmpdir()));
+  assert.ok(path.basename(root).startsWith('tdh-secret-proof-'));
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/scripts/scan-secrets.js
+++ b/scripts/scan-secrets.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+// Deliberately bounded format detection, not a claim of exhaustive coverage.
+const rules = [
+  ['github-token', /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g],
+  ['github-fine-grained-token', /\bgithub_pat_[A-Za-z0-9_]{22,}\b/g],
+  ['vendor-api-key', /\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{32,}\b/g],
+  ['aws-access-key-id', /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g],
+  ['private-key', /-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----/g],
+];
+
+function scan(root) {
+  // Use Git's NUL-delimited tracked-file list, including force-added ignored files.
+  // Git failures must not be treated as an empty repository.
+  const tracked = execFileSync(process.env.TDH_TEST_GIT || 'git', ['ls-files', '--stage', '-z'], {
+    cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], maxBuffer: 16 * 1024 * 1024,
+  });
+  let failures = 0;
+  const report = (file, rule, line) => {
+    // Never print the matched line or secret value.
+    console.error('SECRET_HIT=' + JSON.stringify({ file, rule, ...(line ? { line } : {}) }));
+    failures++;
+  };
+  for (const entry of tracked.split('\0').filter(Boolean)) {
+    const match = entry.match(/^(\d+) [a-f0-9]+ ([0-3])\t([\s\S]+)$/);
+    if (!match) throw new Error('Invalid tracked-file record');
+    const [, mode, stage, file] = match;
+    if (stage !== '0' || !['100644', '100755'].includes(mode)) {
+      report(file, 'unsupported-or-unmerged-file');
+      continue;
+    }
+    const full = path.resolve(root, file);
+    const relative = path.relative(root, full);
+    if (relative.startsWith('..' + path.sep) || path.isAbsolute(relative)) throw new Error('Path outside repository');
+    // Reject symlinks, including symlinked parent directories, before reading.
+    let current = root;
+    let safe = true;
+    for (const part of relative.split(path.sep)) {
+      current = path.join(current, part);
+      if (fs.lstatSync(current).isSymbolicLink()) { safe = false; break; }
+    }
+    if (!safe) { report(file, 'symlink'); continue; }
+    const name = path.basename(file);
+    if (/^\.env(?:\..*)?$/.test(name) && !['.env.example', '.env.sample', '.env.template'].includes(name)) {
+      report(file, 'sensitive-env-file');
+    }
+    const content = fs.readFileSync(full, 'utf8');
+    for (const [id, pattern] of rules) {
+      pattern.lastIndex = 0;
+      const found = pattern.exec(content);
+      if (found) report(file, id, content.slice(0, found.index).split('\n').length);
+    }
+  }
+  return failures === 0;
+}
+
+try {
+  const ok = scan(path.resolve(process.argv[2] || path.join(__dirname, '..')));
+  console.log('SECRET_SCAN_OK=' + Number(ok));
+  if (!ok) process.exitCode = 1;
+} catch (_) {
+  // Avoid exposing subprocess output or file contents on an operational failure.
+  console.error('SECRET_SCAN_ERROR=unable-to-scan-all-tracked-files');
+  process.exitCode = 2;
+}


### PR DESCRIPTION
The existing scan rejects office fingerprints but permits common API credentials and force-added environment files. This preserves all seven office needles and adds a tracked-file secret scan before SCAN_OK=1 can be printed.

The new scanner recognizes common GitHub token prefixes, sk- vendor keys, AWS access-key IDs, private-key headers and sensitive .env filenames. It reports only file/rule/line, never matched contents. Git/read errors, symlinks, gitlinks and unmerged entries fail closed. Template names .env.example, .env.sample and .env.template are allowed but still content-scanned.

The regression proof creates temporary Git repositories, exercises the real shell entrypoint with synthetic vendor/GitHub/cloud/private-key examples, force-added ignored .env files, templates and every original office needle. It verifies redaction, no false success on rejected inputs, allowed placeholders, unreadable files and Git failure. CI explicitly provisions Node 22 and runs both the scan and proof.

Validation: local Windows / Node 24.16.0 / Git Bash: SECRET_SCAN_PROVE_OK=1, SECRET_SCAN_OK=1, SCAN_OK=1, PATCH_PROVE_OK=1 on the existing 0.1.1-rc.2 test prefix, clean diff check. Existing CI validates the current 0.1.2-rc.1 pin. Uploaded tree and executable modes match the local commit.

Limits: bounded format detection, not all vendor formats, arbitrary passwords, entropy analysis, encoded credentials, validity checks, full Git history or untracked files. This checks tracked working-tree contents (the committed snapshot in CI), not independently the local staging-index contents. A Git checkout, Node, Git and Bash are now required; archive-only scans fail instead of reporting green. No real credentials are used or sent to a validation service.

Closes #23.
