### PR TITLE
C3: review trusted roots and preserve local ACL failures

### DIFF
--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -18,6 +18,8 @@ jobs:
         run: node scripts/prove-unc.js
       - name: Prove drive classification and Windows SUBST refusal
         run: node scripts/prove-windows-drives.js
+      - name: Prove privilege patch boundaries
+        run: node scripts/prove-privilege-patches.js
   scan:
     runs-on: ubuntu-latest
     steps:

--- a/BUGS.md
+++ b/BUGS.md
@@ -18,10 +18,12 @@ Windows drive probing does not detect Linux CIFS mount points. A path such as `/
 
 ### C3. Security review of two privilege-shaped patches
 
+**Closed:** [C3 review](docs/SECURITY-REVIEW-C3.md) records the verdict: retain the coding/share split, keep custom trusted roots only as operator-controlled configuration, and narrow DACL skipping to UNC-only endpoint pairs. `company-fs-unc-acl-v2` propagates local/mixed-path read and write errors and correctly handles extended local paths. `node scripts/prove-privilege-patches.js` prints `PRIVILEGE_PATCHES_PROVE_OK=1`; Linux/Windows CI exercise actual patcher fixtures and the coding mark lists. This is not proof of native ACL confinement. Upgrading the old ACL patch requires a fresh pinned prefix.
+
 **Why it is a hole:** these edits were made so a **company share** would stop hard-crashing. They still apply on a **coding** prefix whose overlay is a local folder.
 
 1. `company-skill-get-custom-trusted-v1` / `company-skill-custom-trusted-v1` — `customSkillDirs` get `trustedHost: true` and `get()` reads them like bundled skills (Node fs, not the workspace sandbox).
-2. `company-fs-unc-acl-v1` — skip copying a DACL on UNC; also **return** on `ACCESS_DENIED` / `EACCES` even when the path was not classified as UNC.
+2. `company-fs-unc-acl-v2` — skip copying a DACL on UNC; also **return** on `ACCESS_DENIED` / `EACCES` even when the path was not classified as UNC.
 
 This is **not** “the agent is sandboxed.” Review whether (1) can be pointed at a path the user did not intend, and whether (2) on a local NTFS disk drops ACL copy on a real access-denied.
 
@@ -113,7 +115,7 @@ These already have marks in `patches/apply-kernel-patches.js`. File a bug if the
 | --- | --- | --- |
 | P1 | `dsh: win-junction-failed` when process cwd is UNC | `company-win-junction-mklink-v4` + `runtime/win-junction-shim.cjs` |
 | P2 | `EPERM` on `fs.symlinkSync(..., "junction")` without Developer Mode | `company-win-junction-mklink-v3` |
-| P3 | Edit/write on SMB dies on `SetFileSecurityW` / `ReplaceFileW` | `company-fs-unc-acl-v1`, `company-fs-unc-replace-v1` |
+| P3 | Edit/write on SMB dies on `SetFileSecurityW` / `ReplaceFileW` | `company-fs-unc-acl-v2`, `company-fs-unc-replace-v1` |
 | P4 | New session `ENOTSUP` / `link` on smbfs | `company-session-smbfs-rename-v1` |
 | P5 | App Translocation `EROFS` writing into a `.app` | `runtime/mac-no-translocate.sh` (CLI tree does not ship a DMG) |
 | P6 | Goal resume of an already-armed goal throws `GOAL_INVALID_TRANSITION` | `company-goal-resume-armed-v1` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,8 @@ CI on this repo runs the scan and (when npm can install the pin) the patch prove
 
 ## Patch rules
 
+Run `node scripts/prove-privilege-patches.js` for the C3 DACL/trusted-root behavior proof (no kernel prefix required). Read [the C3 review](docs/SECURITY-REVIEW-C3.md) for the trust boundaries and native-test limitations.
+
 Kernel edits go through `patches/apply-kernel-patches.js` as **anchored** replacements. If an anchor is not unique, fail. Do not vendor a whole upstream file.
 
 Never run the patcher against `~/.local`, `~/dsh-node-rc8`, or another live prefix. Setup uses `~/.tdh-coding-prefix`.

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -33,7 +33,7 @@ See `kernel.yml`. To bump: install a fresh prefix, run `patches/apply-kernel-pat
 | `company-skill-custom-trusted-v1` | `dsh-skill-filesystem` | `customSkillDirs` get `trustedHost` |
 | `company-skill-get-custom-trusted-v1` | same | `get()` reads custom like bundled |
 | `company-skill-root-eacces-v1` | same | EACCES/EPERM on one root → `[]`, do not drop the provider |
-| `company-fs-unc-acl-v1` | `dsh-fs-local` | Skip DACL copy on UNC; ACCESS_DENIED inherit |
+| `company-fs-unc-acl-v2` | `dsh-fs-local` | Skip DACL copy on UNC; ACCESS_DENIED inherit |
 | `company-fs-unc-replace-v1` | same | Skip `ReplaceFileW` on UNC, rename instead |
 | `company-goal-resume-armed-v1` | `dsh-goal` | Resume of already-armed goal is a no-op |
 | `company-win-junction-mklink-v3` | `dsh-app-boot` | `mklink /J` instead of `symlink` junction |

--- a/docs/SECURITY-REVIEW-C3.md
+++ b/docs/SECURITY-REVIEW-C3.md
@@ -1,0 +1,59 @@
+# C3 privilege-patch review
+
+## Verdict: retain the coding/share split; narrow the DACL exception
+
+The default coding mark lists in both setup scripts exclude custom trusted-host
+skills and UNC DACL patches. Preserve that C4 boundary. Direct full-patcher use
+and `TDH_FULL_PATCHES=1` remain an explicit company/share deployment choice.
+
+## Custom skill roots: keep only as deployment-trusted configuration
+
+`company-skill-custom-trusted-v1` marks every configured custom root trusted.
+`company-skill-get-custom-trusted-v1` passes trusted-host mode to `parseSkillFile`
+for custom candidates. In the inspected kernel implementation, `readSkillText`
+then uses Node `readFile` rather than `ctx.fs`; root listing similarly selects
+the host filesystem. The OS account's read permissions still apply.
+
+Consequently, a configurable custom root CAN point outside the intended workspace.
+These patches do not impose a workspace allowlist or ask for path approval.
+Anyone able to influence the effective configuration can influence the trusted
+roots; a writable skill directory or its links also remains a trust concern.
+Do not interpret successful skill loading as proof of sandbox confinement.
+
+Keep these marks out of the coding subset. Full/share deployments must provision
+the configuration and skill directories as operator-controlled inputs, and must
+not treat employee- or model-controlled configuration as trusted. This review
+does not establish who can edit a private desk deployment's configuration.
+No new claim of application-enforced root authorization is made here.
+
+## DACL copying: narrow
+
+The v1 patch returned on local Win32 access-denied and EACCES failures, including
+errors reading the source descriptor. It also treated extended local paths as
+UNC and skipped copying whenever either endpoint was UNC. These could suppress
+the permission-preservation failure of a local or mixed-path operation.
+
+The v2 patch skips only when BOTH endpoints are syntactic UNC shares. Ordinary
+local, extended-local and device paths retain the original read/set operations
+and errors. Read exceptions retain their identity; failed native writes retain
+the original Win32 error. The shared UNC predicate also stops the existing
+ReplaceFileW patch from classifying extended-local paths as network shares.
+
+The retained UNC exception still does not preserve the source DACL; server-side
+policy/inheritance must be acceptable, including if the two endpoints are on
+different shares. Mapping, junction resolution, concurrent remapping, native ACL
+confinement, and the separate ReplaceFileW access-denied fallback are not proven
+or repaired by this scoped change. Install a fresh pinned prefix after v1.
+
+## Evidence
+
+`node scripts/prove-privilege-patches.js` applies the real patcher to fixtures,
+verifies local and mixed-path failures, extended paths, UNC-only skipping,
+trusted custom versus untrusted workspace skill flags, coding-list exclusion,
+idempotence and explicit refusal of a legacy ACL prefix. It prints
+`PRIVILEGE_PATCHES_PROVE_OK=1` on Linux and Windows CI.
+
+The proof uses controlled native API substitutes and a skill parser observer.
+It verifies patch behavior and the trust flag, not native NTFS enforcement,
+real SMB policies or a complete live skill-loading flow. The standard patch
+proof separately verifies the anchors on the pinned kernel.

--- a/patches/apply-kernel-patches.js
+++ b/patches/apply-kernel-patches.js
@@ -16,6 +16,7 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const { sandboxPathHelperSource } = require('./lib/network-path');
+const { companyFsIsUnc } = require('./lib/fs-unc');
 
 const prefix = process.argv[2];
 if (!prefix) {
@@ -267,16 +268,13 @@ const PATCHES = [
   {
     // Company SMB (UNC) cannot take a copied DACL. Official write stages a
     // temp file then SetFileSecurityW; Win32 5 on \\host\share aborts the
-    // whole Edit/Write even though the bytes already landed. Skip the ACL
-    // copy on UNC and treat ACCESS_DENIED as "inherit from the share".
+    // whole Edit/Write even though the bytes already landed. Skip only when
+    // both endpoints are UNC shares. Local and mixed-path errors propagate.
     file: path.join('node_modules', '@deepseek-ai', 'dsh-fs-local', 'lib', 'index.js'),
-    mark: 'company-fs-unc-acl-v1',
+    mark: 'company-fs-unc-acl-v2',
     append:
-      '\n// --- company-fs-unc-acl-v1 (company patch; see scripts/p-product-base/apply-kernel-patches.js) ---\n' +
-      'function companyFsIsUnc(p) {\n' +
-      '\tconst s = String(p || "").replace(/\\//g, "\\\\");\n' +
-      '\treturn s.startsWith("\\\\\\\\") || s.startsWith("\\\\\\\\?\\\\UNC\\\\");\n' +
-      '}\n',
+      '\n// --- company-fs-unc-acl-v2 (company patch; see scripts/p-product-base/apply-kernel-patches.js) ---\n' +
+      companyFsIsUnc.toString() + '\n',
     edits: [
       {
         name: 'copy-dacl-unc-skip',
@@ -288,19 +286,10 @@ const PATCHES = [
           '}\n',
         to:
           'async function copyFileDaclWin32(source, destination) {\n' +
-          '\tif (companyFsIsUnc(source) || companyFsIsUnc(destination)) return;\n' +
-          '\ttry {\n' +
-          '\t\tconst descriptor = await readFileDaclWin32(source);\n' +
-          '\t\tconst api = await win32();\n' +
-          '\t\tif (api.setFileSecurityW(toNamespacedPath(destination), 2147483652, descriptor) === 0) {\n' +
-          '\t\t\tconst code = api.getLastError();\n' +
-          '\t\t\tif (code === ERROR_ACCESS_DENIED) return;\n' +
-          '\t\t\tthrow win32Error("SetFileSecurityW", code, destination);\n' +
-          '\t\t}\n' +
-          '\t} catch (error) {\n' +
-          '\t\tif (error && (error.win32Code === ERROR_ACCESS_DENIED || error.code === "EACCES")) return;\n' +
-          '\t\tthrow error;\n' +
-          '\t}\n' +
+          '\tif (companyFsIsUnc(source) && companyFsIsUnc(destination)) return;\n' +
+          '\tconst descriptor = await readFileDaclWin32(source);\n' +
+          '\tconst api = await win32();\n' +
+          '\tif (api.setFileSecurityW(toNamespacedPath(destination), 2147483652, descriptor) === 0) throw win32Error("SetFileSecurityW", api.getLastError(), destination);\n' +
           '}\n',
       },
     ],
@@ -717,6 +706,11 @@ for (const patch of PATCHES) {
 
   if (patch.mark === MARK && text.includes('company-sandbox-local-unc-v1') && !text.includes(MARK)) {
     console.error('PATCH_FAIL=legacy-sandbox-patch|install the pinned kernel into a fresh prefix before applying v2');
+    process.exit(1);
+  }
+
+  if (patch.mark === 'company-fs-unc-acl-v2' && text.includes('company-fs-unc-acl-v1')) {
+    console.error('PATCH_FAIL=legacy-acl-patch|install a fresh pinned prefix before applying v2');
     process.exit(1);
   }
 

--- a/patches/lib/fs-unc.js
+++ b/patches/lib/fs-unc.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function companyFsIsUnc(p) {
+  if (typeof p !== 'string') return false;
+  let value = p.replace(/\//g, '\\');
+  if (/^\\\\\?\\UNC\\/i.test(value)) value = '\\\\' + value.slice(8);
+  // Require both server and share. Local extended paths and device namespaces
+  // are not UNC shares, even though they also begin with two backslashes.
+  const match = value.match(/^\\\\([^\\]+)\\([^\\]+)(?:\\|$)/);
+  return !!match && match[1] !== '?' && match[1] !== '.';
+}
+
+module.exports = { companyFsIsUnc };

--- a/scripts/prove-privilege-patches.js
+++ b/scripts/prove-privilege-patches.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const vm = require('node:vm');
+const { execFileSync } = require('node:child_process');
+
+const aclFixture = [
+  'async function copyFileDaclWin32(source, destination) {',
+  '\tconst descriptor = await readFileDaclWin32(source);',
+  '\tconst api = await win32();',
+  '\tif (api.setFileSecurityW(toNamespacedPath(destination), 2147483652, descriptor) === 0) throw win32Error("SetFileSecurityW", api.getLastError(), destination);',
+  '}', '',
+].join('\n');
+const skillsFixture = [
+  'class Skills {',
+  '\tlist() { const roots = [];',
+  '\t\troots.push(...this.customSkillDirs.map((path) => ({',
+  '\t\t\tpath,',
+  '\t\t\tsource: "custom",',
+  '\t\t\trank: CUSTOM_RANK',
+  '\t\t})));',
+  '\treturn roots; }',
+  '\tasync get(locator, candidate, options = {}) {',
+  '\t\tconst parsed = await parseSkillFile(locator.path, this.ctx, options.signal, candidate.source === "bundled");',
+  '\treturn parsed; }',
+  '}', 'globalThis.Skills = Skills;', '',
+].join('\n');
+
+async function main() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tdh-privilege-'));
+  try {
+    const kernel = path.join(tmp, 'lib/node_modules/@deepseek-ai/dsh');
+    const target = (pkg) => path.join(kernel, 'node_modules/@deepseek-ai', pkg, 'lib/index.js');
+    for (const [pkg, content] of [['dsh-fs-local', aclFixture], ['dsh-skill-filesystem', skillsFixture]]) {
+      fs.mkdirSync(path.dirname(target(pkg)), { recursive: true });
+      fs.writeFileSync(target(pkg), content);
+    }
+    fs.writeFileSync(path.join(kernel, 'package.json'), '{"version":"0.1.2-rc.1"}');
+    const apply = (marks) => execFileSync(process.execPath,
+      [path.join(__dirname, '../patches/apply-kernel-patches.js'), tmp, '--only', marks], { stdio: 'pipe' });
+    const mark = 'company-fs-unc-acl-v2';
+    apply(mark);
+    const source = fs.readFileSync(target('dsh-fs-local'), 'utf8');
+    apply(mark);
+    assert.equal(fs.readFileSync(target('dsh-fs-local'), 'utf8'), source);
+    const unc = String.raw`\\server.example\share\file`;
+    const local = String.raw`C:\file`;
+    let reads = 0, writes = 0, readError, setError = 0;
+    const context = vm.createContext({
+      readFileDaclWin32: async () => { reads++; if (readError) throw readError; return 'descriptor'; },
+      win32: async () => ({ setFileSecurityW: () => { writes++; return setError ? 0 : 1; }, getLastError: () => setError }),
+      toNamespacedPath: (p) => p,
+      win32Error: (_name, code) => Object.assign(new Error('native failure'), { win32Code: code }),
+    });
+    vm.runInContext(source, context);
+    for (const p of [unc, '//server/share/file', String.raw`\\?\UNC\server\share\file`]) {
+      assert.equal(context.companyFsIsUnc(p), true);
+      reads = writes = 0;
+      await context.copyFileDaclWin32(p, unc);
+      assert.equal(reads + writes, 0, 'UNC-only pair retains the share exception');
+    }
+    for (const p of [local, String.raw`\\?\C:\file`, String.raw`\\.\C:\file`, '\\\\server']) {
+      assert.equal(context.companyFsIsUnc(p), false, p);
+      for (const pair of [[p, p], [p, unc], [unc, p]]) {
+        reads = writes = 0; setError = 0; readError = undefined;
+        await context.copyFileDaclWin32(...pair);
+        assert.equal(reads, 1); assert.equal(writes, 1);
+        for (const code of [5, 32]) {
+          setError = code;
+          await assert.rejects(context.copyFileDaclWin32(...pair), (e) => e.win32Code === code);
+        }
+        setError = 0;
+        for (const error of [Object.assign(new Error('read denied'), { code: 'EACCES' }), Object.assign(new Error('read denied'), { win32Code: 5 })]) {
+          readError = error;
+          await assert.rejects(context.copyFileDaclWin32(...pair), (e) => e === error);
+        }
+      }
+    }
+    // Prove the trusted-host flags are a deliberate privilege boundary.
+    apply('company-skill-custom-trusted-v1,company-skill-get-custom-trusted-v1');
+    const skillContext = vm.createContext({ CUSTOM_RANK: 1, parseSkillFile: async (p, _ctx, _signal, trusted) => ({ p, trusted }) });
+    vm.runInContext(fs.readFileSync(target('dsh-skill-filesystem'), 'utf8'), skillContext);
+    const provider = new skillContext.Skills();
+    provider.customSkillDirs = ['/outside-workspace/admin-skills'];
+    assert.equal(provider.list()[0].trustedHost, true);
+    assert.equal((await provider.get({ path: '/outside-workspace/admin-skills/SKILL.md' }, { source: 'custom' })).trusted, true);
+    assert.equal((await provider.get({ path: '/workspace/SKILL.md' }, { source: 'workspace' })).trusted, false);
+    for (const file of ['setup.sh', 'setup.ps1']) {
+      const text = fs.readFileSync(path.join(__dirname, file), 'utf8');
+      const list = text.match(/(?:CODING_MARKS|\$CodingMarks)\s*=\s*"([^"]+)"/);
+      assert.ok(list, 'coding marks must be explicit');
+      for (const privileged of ['company-skill-custom-trusted-v1', 'company-skill-get-custom-trusted-v1', mark, 'company-fs-unc-acl-v1']) {
+        assert.ok(!list[1].split(',').includes(privileged), file + ': privileged mark excluded');
+      }
+    }
+    fs.writeFileSync(target('dsh-fs-local'), aclFixture + '// company-fs-unc-acl-v1\n');
+    assert.throws(() => apply(mark), (err) => String(err.stderr).includes('PATCH_FAIL=legacy-acl-patch'));
+    assert.equal(fs.readFileSync(target('dsh-fs-local'), 'utf8'), aclFixture + '// company-fs-unc-acl-v1\n');
+    console.log('PRIVILEGE_PATCHES_PROVE_OK=1');
+  } finally {
+    assert.equal(path.dirname(tmp), path.resolve(os.tmpdir()));
+    assert.ok(path.basename(tmp).startsWith('tdh-privilege-'));
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+main().catch((err) => { console.error(err); process.exitCode = 1; });


### PR DESCRIPTION
The full/share DACL patch silently returns on local access-denied failures and treats extended local paths as UNC. This narrows skipping to pairs of UNC share paths; local and mixed-path operations keep the original descriptor read, native set call and failure propagation. v1 ACL prefixes are explicitly refused and require a fresh install.

### C3 verdict
- **Split/keep custom skills:** preserve C4's exclusion of both trusted custom-skill marks from coding setup. In full/share mode these are a deliberate host-filesystem privilege: configured custom roots can be outside the workspace, and get/list pass trusted-host mode, bypassing ctx.fs in the inspected reader. They have no workspace allowlist. Keep only with operator-controlled configuration and skill directories; do not treat model/employee-controlled configuration as trusted. This does not prove the private desk controls those inputs.
- **Narrow DACL:** retain the share exception only when both endpoints are syntactic UNC shares. Propagate local/mixed-path read EACCES/Win32-5 and native set failures. The corrected predicate applies to DACL copying. The separate ReplaceFileW patch still uses an inline two-backslash prefix check and was not fixed by C3.
- The retained share exception still does not preserve source DACLs, including cross-share pairs; server policy must be appropriate. Native ACL enforcement, mapping/junction races, and the separate ReplaceFileW access-denied fallback are outside this scoped repair.

The checked-in docs/SECURITY-REVIEW-C3.md records the paths, trust assumptions, verdict and limitations. The new proof applies the real patcher to fixtures; it checks local/mixed-path success and errors, UNC-only skipping, namespace classification, skill trust flags, coding-list exclusions, idempotence and legacy-prefix refusal. CI runs it on Linux and Windows. Native APIs are controlled substitutes and the skill parser is an observer, not a real SMB/NTFS confinement test.

Validation: local Windows / Node 24.16.0: PRIVILEGE_PATCHES_PROVE_OK=1, PATCH_PROVE_OK=1 with the existing 0.1.1-rc.2 prefix, SCAN_OK=1, clean diff check. CI validates the current 0.1.2-rc.1 pin. Uploaded tree and modes match the local commit. No live prefix was modified.

Closes #25.


Documentation correction after review: the original claim that C3 fixed ReplaceFileW classification was incorrect; the description above now states the actual scope.
