### PR TITLE
C2b: refuse Linux CIFS roots before command confinement

### DIFF
--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -18,6 +18,8 @@ jobs:
         run: node scripts/prove-unc.js
       - name: Prove drive classification and Windows SUBST refusal
         run: node scripts/prove-windows-drives.js
+      - name: Prove Linux CIFS refusal at command confinement
+        run: node scripts/prove-linux-cifs.js
   scan:
     runs-on: ubuntu-latest
     steps:

--- a/BUGS.md
+++ b/BUGS.md
@@ -14,6 +14,10 @@ Each row is work that is **not done**. “Done” means the green line in that s
 
 ### C2b. Linux CIFS mount points
 
+**Closed:** `company-sandbox-linux-cifs-v1` checks Linux `workspace-write` roots at `confine()` before either configured or selected runners. Native `statfs` detects SMB/CIFS/SMB2 filesystem types; probe failures refuse with `COMPANY_WORKSPACE_PROBE_FAILED`, detected network roots with `COMPANY_WORKSPACE_NOT_LOCAL`. Both coding setup lists include the independent mark. `node scripts/prove-linux-cifs.js` prints `LINUX_CIFS_PROVE_OK=1`; Linux also exercises real local paths and a symlink (`LINUX_STATFS_PROVE_OK=1`). The patch proof exercises the actual pinned kernel's `confine` method. Optional `TDH_TEST_CIFS_ROOT` checks an existing CIFS mount without creating one; ordinary CI reports that real-share coverage as skipped.
+
+**Limits:** this checks the root's filesystem, not all descendant mounts, NFS, FUSE-backed remote storage, overlay backing stores or later mount changes. Native synchronous statfs is not cached or bounded by a userspace timeout; an unhealthy mount may block. Read-only mode is unaffected. See [Linux detection notes](docs/LINUX-CIFS.md).
+
 Windows drive probing does not detect Linux CIFS mount points. A path such as `/mnt/team` is still a POSIX path to these helpers. This remains separate from C2; open a child Task before taking it. C2 also does not resolve directory junctions or eliminate a drive-remapping race after the check.
 
 ### C3. Security review of two privilege-shaped patches

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,8 @@ CI on this repo runs the scan and (when npm can install the pin) the patch prove
 
 ## Patch rules
 
+Run `node scripts/prove-linux-cifs.js` for C2b (no kernel prefix). Linux additionally checks native statfs on local paths. Optional `TDH_TEST_CIFS_ROOT` requires refusal of an existing CIFS root without changing mounts. See [the coverage limits](docs/LINUX-CIFS.md).
+
 Kernel edits go through `patches/apply-kernel-patches.js` as **anchored** replacements. If an anchor is not unique, fail. Do not vendor a whole upstream file.
 
 Never run the patcher against `~/.local`, `~/dsh-node-rc8`, or another live prefix. Setup uses `~/.tdh-coding-prefix`.

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -29,6 +29,7 @@ See `kernel.yml`. To bump: install a fresh prefix, run `patches/apply-kernel-pat
 
 | Mark | Package file | One line |
 | --- | --- | --- |
+| `company-sandbox-linux-cifs-v1` | `dsh-sandbox-local` | Refuse Linux CIFS/SMB workspace-write roots at confine before both runner paths; fail closed on statfs errors |
 | `company-sandbox-local-drive-v2` | `dsh-sandbox-local` | Refuse UNC and Windows mapped/SUBST roots before ACL work; fail closed on probe errors; cache verified local drives for 30 seconds to avoid per-command PowerShell startup |
 | `company-skill-custom-trusted-v1` | `dsh-skill-filesystem` | `customSkillDirs` get `trustedHost` |
 | `company-skill-get-custom-trusted-v1` | same | `get()` reads custom like bundled |

--- a/docs/LINUX-CIFS.md
+++ b/docs/LINUX-CIFS.md
@@ -1,0 +1,39 @@
+# Linux CIFS workspace refusal (C2b)
+
+Linux does not call the Windows `materializeAclGrant` method. The independent
+`company-sandbox-linux-cifs-v1` patch inserts a precheck at `confine(argv, policy)`
+before configured-runner and normal runner selection. It applies only to Linux
+workspace-write policies; read-only and other operating systems bypass it.
+
+The check uses Node's `statfsSync(root, { bigint: true })`. Linux reports the
+resolved filesystem through this syscall, including a symlink's target. The
+SMB, CIFS and SMB2 constants come from
+[Linux UAPI magic.h](https://github.com/torvalds/linux/blob/master/include/uapi/linux/magic.h).
+Both coding setup scripts include the mark. Windows drive probing and its cache
+remain separate. No PowerShell, mount command or shell process is launched.
+
+Missing paths, access failures and malformed results fail with
+`COMPANY_WORKSPACE_PROBE_FAILED`. Known SMB/CIFS types fail with
+`COMPANY_WORKSPACE_NOT_LOCAL` before runner selection/profile creation.
+
+This is specifically a CIFS-family root check, not a declaration that all other
+filesystems are local. It does not inspect descendant submounts, NFS/FUSE remote
+storage or overlay backing stores. It does not close races after the check.
+The native synchronous call has no userspace timeout and may block on an
+unhealthy mount. Results are not cached, so each confinement checks again.
+
+## Verification
+
+`node scripts/prove-linux-cifs.js` applies the actual patcher to a fixture and
+checks SMB/CIFS/SMB2 plus signed type representation, refusal before both runner
+paths, local types, malformed/failed probes, read-only bypass, other-platform
+bypass, idempotence and a disconnected-precheck negative control.
+
+`scripts/prove-patches.js` also extracts and exercises the actual patched pinned
+kernel's confine method. Native runner creation and native CIFS mounting are not
+performed by those substituted-type tests.
+
+On Linux the proof queries the real local test directory, a symlink and a missing
+path. Set `TDH_TEST_CIFS_ROOT` to an existing CIFS directory to require real mount
+refusal (`LINUX_CIFS_MOUNT_PROVE_OK=1`). The proof neither mounts nor unmounts a
+share. Without that variable it explicitly reports real-share coverage skipped.

--- a/patches/apply-kernel-patches.js
+++ b/patches/apply-kernel-patches.js
@@ -16,6 +16,7 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const { sandboxPathHelperSource } = require('./lib/network-path');
+const { companyAssertLinuxWorkspace } = require('./lib/linux-cifs');
 
 const prefix = process.argv[2];
 if (!prefix) {
@@ -154,6 +155,24 @@ ${sandboxPathHelperSource()}
 `;
 
 const PATCHES = [
+  {
+    file: path.join('node_modules', '@deepseek-ai', 'dsh-sandbox-local', 'lib', 'index.js'),
+    mark: 'company-sandbox-linux-cifs-v1',
+    append: '\n// --- company-sandbox-linux-cifs-v1 ---\n' + companyAssertLinuxWorkspace.toString() + '\n',
+    edits: [
+      {
+        name: 'linux-statfs-import',
+        from: 'import { spawnSync } from "node:child_process";\n',
+        to: 'import { spawnSync } from "node:child_process";\n'
+          + 'import { statfsSync as companyStatfsSync } from "node:fs";\n',
+      },
+      {
+        name: 'linux-cifs-confine-precheck',
+        from: '\tconfine(argv, policy) {\n',
+        to: '\tconfine(argv, policy) {\n\t\tcompanyAssertLinuxWorkspace(policy);\n',
+      },
+    ],
+  },
   MARKDOWN_SLOT_PATCH,
   {
     file: path.join('node_modules', '@deepseek-ai', 'dsh-sandbox-local', 'lib', 'index.js'),

--- a/patches/lib/linux-cifs.js
+++ b/patches/lib/linux-cifs.js
@@ -1,0 +1,27 @@
+'use strict';
+const { statfsSync: companyStatfsSync } = require('node:fs');
+
+function companyAssertLinuxWorkspace(policy, platform = process.platform, statfs = companyStatfsSync) {
+  if (platform !== 'linux' || policy.mode !== 'workspace-write') return;
+  let type;
+  try {
+    if (typeof policy.workspaceRoot !== 'string' || !policy.workspaceRoot.startsWith('/')) {
+      throw new Error('Expected an absolute Linux workspace path');
+    }
+    const info = statfs(policy.workspaceRoot, { bigint: true });
+    if (!info || typeof info.type !== 'bigint') throw new Error('Invalid statfs response');
+    type = BigInt.asUintN(32, info.type);
+  } catch (cause) {
+    const err = new Error('sandbox-local: cannot determine Linux workspace filesystem; command confinement was not attempted.', { cause });
+    err.code = 'COMPANY_WORKSPACE_PROBE_FAILED';
+    throw err;
+  }
+  // Linux UAPI include/uapi/linux/magic.h: SMB, CIFS and SMB2 superblock types.
+  if ([0x517bn, 0xff534d42n, 0xfe534d42n].includes(type)) {
+    const err = new Error('sandbox-local: refusing workspace-write on a Linux CIFS/SMB filesystem. Use a local workspace directory.');
+    err.code = 'COMPANY_WORKSPACE_NOT_LOCAL';
+    throw err;
+  }
+}
+
+module.exports = { companyAssertLinuxWorkspace };

--- a/scripts/prove-linux-cifs.js
+++ b/scripts/prove-linux-cifs.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const vm = require('node:vm');
+const { execFileSync } = require('node:child_process');
+const { companyAssertLinuxWorkspace } = require('../patches/lib/linux-cifs');
+const mark = 'company-sandbox-linux-cifs-v1';
+
+function proveLinuxKernelSource(source) {
+  const method = source.match(/^\tconfine\(argv, policy\) \{[\s\S]*?^\t\}/m);
+  assert.ok(method, 'real confine method present');
+  const start = source.indexOf('// --- ' + mark);
+  assert.ok(start >= 0, 'Linux helper embedded');
+  for (const custom of [false, true]) {
+    for (const type of [0xef53n, 0x794c7630n, 0xff534d42n, 0xfe534d42n, 0x517bn, BigInt.asIntN(32, 0xff534d42n)]) {
+      const calls = [];
+      const context = vm.createContext({
+        process: { platform: 'linux' },
+        companyStatfsSync: () => { calls.push('statfs'); return { type }; },
+        bwrapProfileArgs: () => { calls.push('profile'); return []; },
+        DENIAL_SIGNATURES: { runnerCommand: [], bwrap: [] }, RUNNER_FAILURE_RULES: { bwrap: [] },
+      });
+      vm.runInContext(source.slice(start) + '\nglobalThis.provider = ({' + method[0] + '\n});', context);
+      const provider = context.provider;
+      Object.defineProperty(provider, 'runnerCommand', { get() { calls.push('runner'); return custom ? ['custom'] : undefined; } });
+      provider.selectRunner = () => { calls.push('select'); return { runner: 'bwrap', enforcement: 'full' }; };
+      provider.runnerArgv = () => { calls.push('argv'); return ['bwrap']; };
+      const policy = { mode: 'workspace-write', workspaceRoot: '/mnt/team' };
+      if ([0xef53n, 0x794c7630n].includes(type)) {
+        provider.confine(['true'], policy);
+        assert.equal(calls[0], 'statfs');
+        assert.ok(calls.includes(custom ? 'profile' : 'select'));
+      } else {
+        assert.throws(() => provider.confine(['true'], policy), (err) => err.code === 'COMPANY_WORKSPACE_NOT_LOCAL');
+        assert.deepEqual(calls, ['statfs'], 'refuse before both runner paths');
+      }
+      calls.length = 0;
+      provider.confine(['true'], { ...policy, mode: 'read-only' });
+      assert.ok(!calls.includes('statfs'), 'read-only does not probe mounts');
+      context.companyStatfsSync = () => { throw new Error('probe unavailable'); };
+      calls.length = 0;
+      assert.throws(() => provider.confine(['true'], policy), (err) => err.code === 'COMPANY_WORKSPACE_PROBE_FAILED');
+      assert.deepEqual(calls, []);
+    }
+  }
+}
+
+function main() {
+  const policy = { mode: 'workspace-write', workspaceRoot: '/mnt/team' };
+  for (const response of [undefined, {}, { type: 'cifs' }, { type: 0xff534d42 }]) {
+    assert.throws(() => companyAssertLinuxWorkspace(policy, 'linux', () => response), { code: 'COMPANY_WORKSPACE_PROBE_FAILED' });
+  }
+  for (const platform of ['win32', 'darwin']) {
+    companyAssertLinuxWorkspace(policy, platform, () => { throw new Error('must not probe'); });
+  }
+  assert.throws(() => companyAssertLinuxWorkspace({ ...policy, workspaceRoot: 'relative' }, 'linux'), { code: 'COMPANY_WORKSPACE_PROBE_FAILED' });
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tdh-cifs-'));
+  try {
+    const kernel = path.join(tmp, 'lib/node_modules/@deepseek-ai/dsh');
+    const target = path.join(kernel, 'node_modules/@deepseek-ai/dsh-sandbox-local/lib/index.js');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(path.join(kernel, 'package.json'), '{"version":"0.1.2-rc.1"}');
+    const fixture = 'import { spawnSync } from "node:child_process";\nclass Sandbox {\n'
+      + '\tconfine(argv, policy) {\n'
+      + '\t\tif (this.runnerCommand !== void 0) return bwrapProfileArgs(policy);\n'
+      + '\t\treturn this.selectRunner(policy.mode);\n\t}\n}\n';
+    fs.writeFileSync(target, fixture);
+    const apply = () => execFileSync(process.execPath,
+      [path.join(__dirname, '../patches/apply-kernel-patches.js'), tmp, '--only', mark], { stdio: 'pipe' });
+    apply();
+    const patched = fs.readFileSync(target, 'utf8');
+    assert.match(patched, /import \{ statfsSync as companyStatfsSync \} from "node:fs";/);
+    apply();
+    assert.equal(fs.readFileSync(target, 'utf8'), patched);
+    proveLinuxKernelSource(patched);
+    const disconnected = patched.replace('\t\tcompanyAssertLinuxWorkspace(policy);\n', '');
+    assert.notEqual(disconnected, patched);
+    assert.throws(() => proveLinuxKernelSource(disconnected), { code: 'ERR_ASSERTION' });
+    const fileIndex = process.argv.indexOf('--sandbox-file');
+    if (fileIndex >= 0) {
+      proveLinuxKernelSource(fs.readFileSync(process.argv[fileIndex + 1], 'utf8'));
+      console.log('LINUX_CIFS_KERNEL_PROVE_OK=1');
+    }
+    if (process.platform === 'linux') {
+      companyAssertLinuxWorkspace({ ...policy, workspaceRoot: tmp });
+      const link = path.join(tmp, 'local-link');
+      fs.symlinkSync(path.dirname(tmp), link);
+      try { companyAssertLinuxWorkspace({ ...policy, workspaceRoot: link }); }
+      finally { fs.unlinkSync(link); }
+      assert.throws(() => companyAssertLinuxWorkspace({ ...policy, workspaceRoot: path.join(tmp, 'absent') }), { code: 'COMPANY_WORKSPACE_PROBE_FAILED' });
+      if (process.env.TDH_TEST_CIFS_ROOT) {
+        assert.throws(() => companyAssertLinuxWorkspace({ ...policy, workspaceRoot: process.env.TDH_TEST_CIFS_ROOT }), { code: 'COMPANY_WORKSPACE_NOT_LOCAL' });
+        console.log('LINUX_CIFS_MOUNT_PROVE_OK=1');
+      } else console.log('LINUX_CIFS_MOUNT_SKIP=no-existing-CIFS-root-provided');
+      console.log('LINUX_STATFS_PROVE_OK=1');
+    } else console.log('LINUX_STATFS_SKIP=requires-Linux');
+    console.log('LINUX_CIFS_PROVE_OK=1');
+  } finally {
+    assert.equal(path.dirname(tmp), path.resolve(os.tmpdir()));
+    assert.ok(path.basename(tmp).startsWith('tdh-cifs-'));
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+if (require.main === module) main();
+module.exports = { proveLinuxKernelSource };

--- a/scripts/prove-patches.js
+++ b/scripts/prove-patches.js
@@ -132,6 +132,8 @@ execFileSync(process.execPath, [path.join(root, 'scripts', 'prove-unc.js'),
 });
 execFileSync(process.execPath, [path.join(root, 'scripts', 'prove-windows-drives.js'),
   '--sandbox-file', path.join(dst, SANDBOX_FILE)], { stdio: 'inherit' });
+execFileSync(process.execPath, [path.join(root, 'scripts', 'prove-linux-cifs.js'),
+  '--sandbox-file', path.join(dst, SANDBOX_FILE)], { stdio: 'inherit' });
 
 if (bad) {
   console.error('PATCH_PROVE_OK=0');

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -17,7 +17,7 @@ npm install -g "@deepseek-ai/dsh@$Pin" --prefix $Prefix
 # Coding setup applies only the local-workspace subset; the company pins
 # (__DESK_SKILLS__ skill roots, web_fetch, .company-root) stay off the
 # official presets unless TDH_FULL_PATCHES=1 (see C4 in BUGS.md).
-$CodingMarks = "company-sandbox-local-drive-v2,company-win-junction-mklink-v3,company-win-junction-mklink-v4,company-glob-missing-root-v1,company-session-smbfs-rename-v1,company-goal-resume-armed-v1,company-session-events-alias-v1"
+$CodingMarks = "company-sandbox-local-drive-v2,company-sandbox-linux-cifs-v1,company-win-junction-mklink-v3,company-win-junction-mklink-v4,company-glob-missing-root-v1,company-session-smbfs-rename-v1,company-goal-resume-armed-v1,company-session-events-alias-v1"
 if ($env:TDH_FULL_PATCHES -eq "1") {
   node (Join-Path $Root "patches\apply-kernel-patches.js") $Prefix
 } else {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,7 +19,7 @@ npm install -g "@deepseek-ai/dsh@${PIN}" --prefix "$PREFIX"
 # and .company-root into the official presets, which overlays/solo.yml does
 # not define (C4). TDH_FULL_PATCHES=1 restores the old full-pin behavior for
 # the company desk tree.
-CODING_MARKS="company-sandbox-local-drive-v2,company-win-junction-mklink-v3,company-win-junction-mklink-v4,company-glob-missing-root-v1,company-session-smbfs-rename-v1,company-goal-resume-armed-v1,company-session-events-alias-v1"
+CODING_MARKS="company-sandbox-local-drive-v2,company-sandbox-linux-cifs-v1,company-win-junction-mklink-v3,company-win-junction-mklink-v4,company-glob-missing-root-v1,company-session-smbfs-rename-v1,company-goal-resume-armed-v1,company-session-events-alias-v1"
 if [ "${TDH_FULL_PATCHES:-}" = "1" ]; then
   node "$ROOT/patches/apply-kernel-patches.js" "$PREFIX"
 else


### PR DESCRIPTION
Linux never reaches the Windows materializeAclGrant precheck, so a CIFS-mounted POSIX workspace still receives workspace-write confinement. This adds independent mark company-sandbox-linux-cifs-v1 at confine(), before both configured and normal runner paths. Both coding setup lists include it.

Linux workspace-write calls native statfs with bigint fields, recognizing Linux UAPI SMB/CIFS/SMB2 filesystem types (including signed representation). A detected type refuses with COMPANY_WORKSPACE_NOT_LOCAL; missing paths, probe errors and malformed results fail closed with COMPANY_WORKSPACE_PROBE_FAILED. Read-only mode and other platforms bypass this Linux check. No external process is spawned and results are not cached.

The proof applies the real patcher, checks ordering before both runner paths, bypasses, filesystem types, probe failures, idempotence and a disconnected-call negative control. prove-patches also exercises confine extracted from the actual patched kernel. Linux CI additionally checks native statfs on a local directory, a symlink and a missing path. TDH_TEST_CIFS_ROOT optionally requires refusal of an existing real CIFS directory; normal CI explicitly skips that real-share coverage, without creating or removing mounts.

Local Windows / Node 24.16.0: LINUX_CIFS_PROVE_OK=1, LINUX_CIFS_KERNEL_PROVE_OK=1, PATCH_PROVE_OK=1 on existing 0.1.1-rc.2 test prefix, SCAN_OK=1, clean diff check. CI verifies the current 0.1.2-rc.1 pin. Uploaded tree and file modes match local.

Limits: only the root filesystem is checked, not descendant mounts, NFS/FUSE remote storage or overlay backing stores. This does not prevent mount races after the check. Synchronous native statfs has no userspace timeout and can block on an unhealthy mount. Windows drive probing/cache remain separate. See docs/LINUX-CIFS.md for the source constants and coverage boundaries.

Closes #27.
